### PR TITLE
Update error message

### DIFF
--- a/lib/dry/types/maybe.rb
+++ b/lib/dry/types/maybe.rb
@@ -14,7 +14,7 @@ module Dry
 
       def default(value)
         if value.nil?
-          raise ArgumentError, "nil cannot be used as a default of an optional type"
+          raise ArgumentError, "nil cannot be used as a default of a maybe type"
         else
           super
         end


### PR DESCRIPTION
Actually after renaming Optional to Maybe we _can_ use nil as a default.
`Types::String.optional.default(nil)['foo'] => "foo"`