### PR TITLE
Fix Struct grandchildren skipping schema checks

### DIFF
--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -15,6 +15,8 @@ module Dry
           klass.instance_variable_set('@constructor', Types['coercible.hash'])
           Types.register_class(klass)
         end
+
+        klass.attributes({}) unless equal?(Struct)
       end
 
       def self.equalizer

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -9,10 +9,14 @@ RSpec.describe Dry::Types::Struct do
         attribute :zipcode, "coercible.string"
       end
 
-      class User < Dry::Types::Struct
+      # This abstract user guarantees User preserves schema definition
+      class AbstractUser < Dry::Types::Struct
         attribute :name, "coercible.string"
         attribute :age, "coercible.int"
         attribute :address, "test.address"
+      end
+
+      class User < AbstractUser
       end
 
       class SuperUser < User


### PR DESCRIPTION
As mentioned in the corresponding issue, schema checks were only skipped when the inheriting child did not define new attributes.

Fixes #62