### PR TITLE
Improve test coverage for `Struct`, kill dead code, and tighten interface

### DIFF
--- a/lib/dry/types/errors.rb
+++ b/lib/dry/types/errors.rb
@@ -18,6 +18,12 @@ module Dry
 
     StructError = Class.new(TypeError)
 
+    class RepeatedAttributeError < ArgumentError
+      def initialize(key)
+        super("Attribute :#{key} has already been defined")
+      end
+    end
+
     ConstraintError = Class.new(TypeError) do
       attr_reader :result
 

--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -63,8 +63,8 @@ module Dry
         else
           super(constructor[attributes])
         end
-      rescue SchemaError, SchemaKeyError => e
-        raise StructError, "[#{self}.new] #{e.message}"
+      rescue SchemaError, SchemaKeyError => error
+        raise StructError, "[#{self}.new] #{error}"
       end
 
       def initialize(attributes)

--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -58,7 +58,7 @@ module Dry
       end
 
       def self.new(attributes = {})
-        if attributes.is_a?(self)
+        if attributes.instance_of?(self)
           attributes
         else
           super(constructor[attributes])

--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -8,7 +8,7 @@ module Dry
       def self.inherited(klass)
         super
 
-        klass.instance_variable_set('@equalizer', Equalizer.new)
+        klass.instance_variable_set('@equalizer', Equalizer.new(*schema.keys))
         klass.send(:include, klass.equalizer)
 
         unless klass == Value
@@ -36,7 +36,7 @@ module Dry
         @constructor = Types['coercible.hash'].public_send(constructor_type, schema)
 
         attr_reader(*new_schema.keys)
-        equalizer.instance_variable_get('@keys').concat(schema.keys).uniq!
+        equalizer.instance_variable_get('@keys').concat(new_schema.keys)
 
         self
       end

--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -28,6 +28,8 @@ module Dry
       end
 
       def self.attributes(new_schema)
+        check_schema_duplication(new_schema)
+
         prev_schema = schema
 
         @schema = prev_schema.merge(new_schema)
@@ -38,6 +40,13 @@ module Dry
 
         self
       end
+
+      def self.check_schema_duplication(new_schema)
+        shared_keys = new_schema.keys & schema.keys
+
+        fail RepeatedAttributeError, shared_keys.first if shared_keys.any?
+      end
+      private_class_method :check_schema_duplication
 
       def self.constructor_type(type = :strict)
         @constructor_type ||= type

--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -33,7 +33,7 @@ module Dry
         @schema = prev_schema.merge(new_schema)
         @constructor = Types['coercible.hash'].public_send(constructor_type, schema)
 
-        attr_reader(*(new_schema.keys - prev_schema.keys))
+        attr_reader(*new_schema.keys)
         equalizer.instance_variable_get('@keys').concat(schema.keys).uniq!
 
         self

--- a/lib/dry/types/value.rb
+++ b/lib/dry/types/value.rb
@@ -3,7 +3,7 @@ require 'dry/types/struct'
 module Dry
   module Types
     class Value < Struct
-      def self.new(*, &_block)
+      def self.new(*)
         super.freeze
       end
     end

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe Dry::Types::Struct do
         end
       }.to raise_error(ArgumentError)
     end
+
+    it 'raises error when attribute is defined twice' do
+      expect {
+        class Test::Foo < Dry::Types::Struct
+          attribute :bar, 'strict.string'
+          attribute :bar, 'strict.string'
+        end
+      }.to raise_error(
+        Dry::Types::RepeatedAttributeError,
+        'Attribute :bar has already been defined'
+      )
+    end
   end
 
   describe 'with a blank schema' do

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -131,6 +131,13 @@ RSpec.describe Dry::Types::Struct do
     end
   end
 
+  describe '.inherited' do
+    it 'does not register Value' do
+      expect { Dry::Types::Struct.inherited(Dry::Types::Value) }
+        .to_not change(Dry::Types, :type_keys)
+    end
+  end
+
   describe 'with a blank schema' do
     it 'works for blank structs' do
       class Test::Foo < Dry::Types::Struct; end

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -159,13 +159,13 @@ RSpec.describe Dry::Types::Struct do
     end
   end
 
-  describe '#to_h' do
+  describe '#to_hash' do
     it 'returns hash with attributes' do
       attributes = {
         name: 'Jane', age: 21, address: { city: 'NYC', zipcode: '123' }
       }
 
-      expect(user_type[attributes].to_h).to eql(attributes)
+      expect(user_type[attributes].to_hash).to eql(attributes)
     end
   end
 end

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe Dry::Types::Struct do
 
       expect(user.address).to be(address)
     end
+
+    it 'creates an empty struct when called without arguments' do
+      class Test::Empty < Dry::Types::Struct
+        @constructor = Dry::Types['strict.hash'].strict(schema)
+      end
+
+      expect { Test::Empty.new }.to_not raise_error
+    end
   end
 
   describe '.attribute' do

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -107,6 +107,20 @@ RSpec.describe Dry::Types::Struct do
         'Attribute :bar has already been defined'
       )
     end
+
+    it 'can be chained' do
+      class Test::Foo < Dry::Types::Struct
+      end
+
+      Test::Foo
+        .attribute(:foo, 'strict.string')
+        .attribute(:bar, 'strict.int')
+
+      foo = Test::Foo.new(foo: 'foo', bar: 123)
+
+      expect(foo.foo).to eql('foo')
+      expect(foo.bar).to eql(123)
+    end
   end
 
   describe 'with a blank schema' do

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -74,4 +74,18 @@ RSpec.shared_examples_for Dry::Types::Struct do
       end
     end
   end
+
+  describe '#inspect' do
+    let(:user_1) do
+      type[
+        name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
+      ]
+    end
+
+    it 'lists attributes' do
+      expect(user_1.inspect).to eql(
+        %Q(#<#{type.primitive} name="Jane" age=21 address=#<Test::Address city="NYC" zipcode="123"> root=true>)
+      )
+    end
+  end
 end


### PR DESCRIPTION
I'm using mutant to reveal which parts of `Dry::Types::Struct` are not covered by tests. So far I have addressed the following mutations with (somewhat) opinionated changes.

**1. `attr_reader` mutation**

Passing a key to `attr_reader` twice shouldn't matter in terms of behavior
or performance so I figured it was safe to make this change:

```diff
@@ -1,9 +1,9 @@
 def self.attributes(new_schema)
   prev_schema = schema
   @schema = prev_schema.merge(new_schema)
   @constructor = Types["coercible.hash"].public_send(constructor_type, schema)
-  attr_reader(*(new_schema.keys - prev_schema.keys))
+  attr_reader(*new_schema.keys)
   equalizer.instance_variable_get("@keys").concat(schema.keys).uniq!
   self
 end
```

**2. non-unique `@keys` on `Struct`'s equalizer**

This mutation is more tricky. The current release of dry-types lets me do this:

```ruby
class Foo < Dry::Types::Struct
  attribute :foo, 'strict.string'
  attribute :foo, 'strict.string'
end
```

This behavior should be rejected. It makes our code simpler if we don't have to
think about cleaning up after a sloppy user who repeats attribute definitions.

This also benefits the user because it makes it impossible to either

1. add dead code by repeating the same type definition
2. overwrite a type definition by accident

Therefore I've added a check to `Struct.attributes` which will throw an error if the user redefines an attribute.

**3. Returning `self` from `attributes`**

I added a test for this behavior since `Struct.attributes` and `Struct.attribute`
both are definitely public API and I'm sure the returning `self` behavior is
intentional.

**4. Calling `.new()` on an empty struct subclass**

I've added a test guaranteeing the behavior of empty structs being initialized with a hash if `.new` is called without arguments. This is the current behavior so it is probably important this behavior doesn't regress. Alternatively I think it would also be appropriate to make it impossible to initialize a struct with zero arguments