### PR TITLE
Add coercible.symbol type

### DIFF
--- a/lib/dry/types/coercions/symbol.rb
+++ b/lib/dry/types/coercions/symbol.rb
@@ -1,0 +1,20 @@
+require 'date'
+require 'bigdecimal'
+require 'bigdecimal/util'
+require 'time'
+
+module Dry
+  module Types
+    module Coercions
+      module Symbol
+        def self.to_symbol(input)
+          if input.respond_to?(:to_sym)
+            input.to_sym
+          else
+            input
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/types/core.rb
+++ b/lib/dry/types/core.rb
@@ -65,4 +65,5 @@ module Dry
   end
 end
 
+require 'dry/types/symbol'
 require 'dry/types/form'

--- a/lib/dry/types/symbol.rb
+++ b/lib/dry/types/symbol.rb
@@ -1,0 +1,9 @@
+require 'dry/types/coercions/symbol'
+
+module Dry
+  module Types
+    register('coercible.symbol') do
+      self['symbol'].constructor(Coercions::Symbol.method(:to_symbol))
+    end
+  end
+end

--- a/spec/dry/types/types/primitive_spec.rb
+++ b/spec/dry/types/types/primitive_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe Dry::Types, '.[]' do
     end
   end
 
+  context 'with "coercible.symbol"' do
+    let(:type) { Dry::Types['coercible.symbol'] }
+
+    it 'passes through a symbol' do
+      expect(type[:hello]).to be(:hello)
+    end
+
+    it 'coerces a string' do
+      expect(type['hello']).to be(:hello)
+    end
+  end
+
   context 'with "class"' do
     let(:type) { Dry::Types['class'] }
 


### PR DESCRIPTION
I believe this addresses #47. The issue also mentions `strict.symbol` but it looks like @solnic added that a while ago https://github.com/dry-rb/dry-types/commit/761e75902a5c063116572c6fe9e25b3d2660d430.