### PR TITLE
Improve test coverage for `Result`, `Definition`, and `JSON.to_decimal`

### DIFF
--- a/lib/dry/types/coercions/json.rb
+++ b/lib/dry/types/coercions/json.rb
@@ -10,11 +10,7 @@ module Dry
         extend Coercions
 
         def self.to_decimal(input)
-          if input.is_a?(String) && input == ''
-            nil
-          else
-            input.to_d
-          end
+          input.to_d unless empty_str?(input)
         end
       end
     end

--- a/lib/dry/types/definition.rb
+++ b/lib/dry/types/definition.rb
@@ -39,12 +39,10 @@ module Dry
       alias_method :[], :call
 
       def try(input, &block)
-        output = call(input)
-
-        if valid?(output)
-          success(output)
+        if valid?(input)
+          success(input)
         else
-          failure = failure(output, "#{output.inspect} must be an instance of #{primitive}")
+          failure = failure(input, "#{input.inspect} must be an instance of #{primitive}")
           block ? yield(failure) : failure
         end
       end

--- a/spec/dry/types/definition_spec.rb
+++ b/spec/dry/types/definition_spec.rb
@@ -16,33 +16,37 @@ RSpec.describe Dry::Types::Definition do
   end
 
   describe '#try' do
-    subject(:try) { type.try(value) }
-
-    let(:success) { try.success?    }
-    let(:failure) { try.failure?    }
-    let(:input)   { try.input       }
+    let(:result) { type.try(value) }
 
     context 'when given valid input' do
       let(:value) { 'foo' }
 
-      specify { expect(success).to be(true)  }
-      specify { expect(failure).to be(false) }
-      specify { expect(input).to be(value)   }
+      it 'returns a success' do
+        expect(result).to be_success
+      end
+
+      it 'provides the original input' do
+        expect(result.input).to be(value)
+      end
     end
 
     context 'when given invalid input' do
       let(:value) { :foo }
 
-      specify { expect(success).to be(false) }
-      specify { expect(failure).to be(true)  }
-      specify { expect(input).to be(value)   }
+      it 'returns a failure' do
+        expect(result).to be_failure
+      end
+
+      it 'provides the original input' do
+        expect(result.input).to be(value)
+      end
 
       it "provides an error message" do
-        expect(try.error).to eql(':foo must be an instance of String')
+        expect(result.error).to eql(':foo must be an instance of String')
       end
 
       it "yields failure when given a block" do
-        expect { |probe| type.try(value, &probe) }.to yield_with_args(try)
+        expect { |probe| type.try(value, &probe) }.to yield_with_args(result)
       end
     end
   end

--- a/spec/dry/types/definition_spec.rb
+++ b/spec/dry/types/definition_spec.rb
@@ -14,4 +14,36 @@ RSpec.describe Dry::Types::Definition do
       expect(coercible_string[{}]).to eql({}.to_s)
     end
   end
+
+  describe '#try' do
+    subject(:try) { type.try(value) }
+
+    let(:success) { try.success?    }
+    let(:failure) { try.failure?    }
+    let(:input)   { try.input       }
+
+    context 'when given valid input' do
+      let(:value) { 'foo' }
+
+      specify { expect(success).to be(true)  }
+      specify { expect(failure).to be(false) }
+      specify { expect(input).to be(value)   }
+    end
+
+    context 'when given invalid input' do
+      let(:value) { :foo }
+
+      specify { expect(success).to be(false) }
+      specify { expect(failure).to be(true)  }
+      specify { expect(input).to be(value)   }
+
+      it "provides an error message" do
+        expect(try.error).to eql(':foo must be an instance of String')
+      end
+
+      it "yields failure when given a block" do
+        expect { |probe| type.try(value, &probe) }.to yield_with_args(try)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- 100% mutation coverage on `JSON.to_decimal`
- Brings mutation coverage of Result* up to 100% from 58.33%
- Specifies behavior of Definition#try

Result::Success and Result::Failure seem simple enough to assume that
they are implementation details so I tested the behavior through
Definition#try