### PR TITLE
Inherit the constructor_type on Struct

### DIFF
--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -9,6 +9,7 @@ module Dry
         super
 
         klass.instance_variable_set('@equalizer', Equalizer.new(*schema.keys))
+        klass.instance_variable_set('@constructor_type', constructor_type)
         klass.send(:include, klass.equalizer)
 
         unless klass == Value
@@ -48,8 +49,12 @@ module Dry
       end
       private_class_method :check_schema_duplication
 
-      def self.constructor_type(type = :strict)
-        @constructor_type ||= type
+      def self.constructor_type(type = nil)
+        if type
+          @constructor_type = type
+        else
+          @constructor_type || :strict
+        end
       end
 
       def self.schema

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -138,6 +138,14 @@ RSpec.describe Dry::Types::Struct do
     end
   end
 
+  describe 'when inheriting a struct from another struct' do
+    it 'also inherits the constructor_type' do
+      class Test::Parent < Dry::Types::Struct; constructor_type(:schema); end
+      class Test::Child < Test::Parent; end
+      expect(Test::Child.constructor_type).to eql(:schema)
+    end
+  end
+
   describe 'with a blank schema' do
     it 'works for blank structs' do
       class Test::Foo < Dry::Types::Struct; end


### PR DESCRIPTION
Previous behavior was

```ruby
class User < Dry::Types::Struct
  constructor_type(:schema)
end

class Admin < User; end;

p User.constructor_type
=> :schema
p Admin.constructor_type
=> :strict
```

This PR makes sure `Admin`'s constructor type would be `:schema` here.