### PR TITLE
Add Hash schema type `strict_with_defaults`

### DIFF
--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -23,6 +23,10 @@ module Dry
         schema(type_map, Strict)
       end
 
+      def strict_with_defaults(type_map)
+        schema(type_map, StrictWithDefaults)
+      end
+
       def symbolized(type_map)
         schema(type_map, Symbolized)
       end

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -96,6 +96,25 @@ module Dry
         end
         alias_method :[], :call
       end
+
+      class StrictWithDefaults < Schema
+        def call(hash, meth = :call)
+          member_types.each_with_object({}) do |(key, type), result|
+            begin
+              value = hash.fetch(key) do
+                resolve_missing_value(result, key, type) or raise SchemaKeyError.new(key)
+              end
+
+              result[key] = type.__send__(meth, value)
+            rescue TypeError
+              raise SchemaError.new(key, value)
+            rescue KeyError
+              raise SchemaKeyError.new(key)
+            end
+          end
+        end
+        alias_method :[], :call
+      end
     end
   end
 end

--- a/spec/dry/types/hash/strict_with_defaults_spec.rb
+++ b/spec/dry/types/hash/strict_with_defaults_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Dry::Types::Hash, '#strict_with_defaults' do
+  subject(:hash) do
+    Dry::Types['hash'].strict_with_defaults(
+      age: 'strict.int',
+      name: name
+    )
+  end
+
+  let(:name) { Dry::Types['strict.string'].default('New User') }
+
+  describe '#[]' do
+    it 'sets default values' do
+      result = hash[age: 18]
+
+      expect(result).to include(
+        name: 'New User', age: 18
+      )
+    end
+
+    it 'raises an error for attributes without default values' do
+      expect { hash[name: 'Jane'] }.to raise_error(Dry::Types::SchemaKeyError)
+    end
+  end
+end


### PR DESCRIPTION
`Dry::Types` structs frustrate me right now and I'm probably going to open a separate issue later that goes further in depth. Basically, I want a struct constructor which throws errors if expected keys are omitted *unless* the corresponding attribute has a default value in which case the default value should be set. That is wordy so here is an example:

```ruby
class User < Dry::Types::Struct
  attribute :age, Dry::Types['strict.int']
  attribute :name, Dry::Types['strict.string'].default('No Name')
end

User.new(age: 18)     # Should set name to "No name"
User.new(name: 'Jim') # Should throw an error
```

This isn't an option right now. I can use `constructor_type(:schema)` if I want default values to be applied when a key is provided, but then I get this behavior:

```ruby
require 'dry/types'

class User < Dry::Types::Struct
  constructor_type(:schema)

  attribute :age, Dry::Types['strict.int']
  attribute :name, Dry::Types['strict.string'].default('No Name')
end

User.new # => #<User age=nil name="No Name">
```

I still want to blow up if `age` isn't provided.

Currently this isn't really resolvable without changing the behavior of `Dry::Types::Hash::Schema` which seems to be by design: see [compiler_spec.rb on master](https://github.com/dry-rb/dry-types/blob/ee77e3d871067911393c293c2577e745957ba2c4/spec/dry/types/compiler_spec.rb#L170-L172).

My solution for now is to propose that `strict_with_defaults` be a new `constructor_type` for `Types::Hash`. I think this topic merits a design discussion which is why I want to open a related issue but in the meantime I think this is an appropriate addition.
