### PR TITLE
Make safe schema intolerant to nils for strict types

### DIFF
--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -25,7 +25,7 @@ module Dry
         def resolve_missing_value(result, key, type)
           if type.is_a?(Default)
             result[key] = type.evaluate
-          elsif type.is_a?(Maybe)
+          else
             result[key] = type[nil]
           end
         end

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
 
     result = hash[foo: 'bar', email: 'jane@doe.org', admin: '1']
 
-    expect(result).to eql(email: 'jane@doe.org', admin: true)
+    expect(result).to eql(email: 'jane@doe.org', admin: true, age: nil)
   end
 
   it 'builds a coercible hash with symbolized keys' do
@@ -99,7 +99,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     )
 
     expect(hash['foo' => 'bar', 'age' => '20', 'admin' => '1']).to eql(
-      age: 20, admin: true
+      age: 20, admin: true, email: nil
     )
   end
 
@@ -133,7 +133,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     ])
 
     expect(arr[['foo' => 'bar', 'age' => '20', 'admin' => '1']]).to eql([
-      age: 20, admin: true
+      age: 20, admin: true, email: nil
     ])
   end
 
@@ -168,7 +168,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     )
 
     expect(hash['foo' => 'bar', 'age' => '20', 'admin' => '1']).to eql(
-      age: 20, admin: true
+      age: 20, admin: true, email: nil
     )
   end
 

--- a/spec/dry/types/hash/symbolized_spec.rb
+++ b/spec/dry/types/hash/symbolized_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Dry::Types::Hash, ':symbolized constructor' do
   subject(:hash) do
     Dry::Types['hash'].symbolized(
-      name: 'string',
+      name: 'strict.string',
       middle_name: 'maybe.strict.string',
-      age: 'int',
+      age: Dry::Types['strict.int'].optional,
       password: password
     )
   end
@@ -23,7 +23,7 @@ RSpec.describe Dry::Types::Hash, ':symbolized constructor' do
       )
     end
 
-    it 'sets None as a default value for optional' do
+    it 'sets None as a default value for maybe' do
       result = hash['name' => 'Jane', 'age' => 1]
 
       expect(result[:middle_name]).to be_instance_of(Kleisli::Maybe::None)
@@ -34,6 +34,19 @@ RSpec.describe Dry::Types::Hash, ':symbolized constructor' do
 
       expect(result).to include(name: 'Jane', age: 1, password: 'changeme')
       expect(result[:middle_name].value).to eql('Alice')
+    end
+
+    it 'raises an error on attempt to omit key associated with a strict type' do
+      expect { hash[middle_name: 'Alice'] }.to raise_error(
+        Dry::Types::ConstraintError,
+        'nil violates constraints (type?(String) failed)'
+      )
+    end
+
+    it 'sets nil as a default value for optional' do
+      result = hash['name' => 'Jane']
+
+      expect(result[:age]).to be_nil
     end
   end
 end


### PR DESCRIPTION
I believe with Optional type (that actually is just an instance of Sum type) we can bring more strictness to Safe/Symbolized schemas. The constructor will set nils automatically if you define type as optional. That seems to me more consistent than having an object with empty values for strict types:
```ruby
gordon@mac ~/dev/dry-types [master] $ ./bin/console
2.3.0 :001 > class Foo < Dry::Types::Struct
2.3.0 :002?>   constructor_type :schema
2.3.0 :003?>   attribute :required, Dry::Types['strict.int']
2.3.0 :004?> end
 => Foo
2.3.0 :005 > Foo.new({})
 => #<Foo required=nil>
2.3.0 :006 >
```