### PR TITLE
Fix compiler crash on empty hash schema, 74

### DIFF
--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -77,7 +77,7 @@ module Dry
 
       def merge_with(hash_id, constructor, schema)
         registry[hash_id].__send__(
-          constructor, schema.map { |key| visit(key) }.reduce(:merge)
+          constructor, schema.map { |key| visit(key) }.reduce({}, :merge)
         )
       end
     end

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -103,6 +103,18 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     )
   end
 
+  it 'builds a hash with empty schema' do
+    ast = [
+      :type, [
+        'hash', [:schema, []]
+      ]
+    ]
+
+    hash = compiler.(ast)
+
+    expect(hash['foo' => 'bar']).to eql({})
+  end
+
   it 'builds an array' do
     ast = [
       :type, [


### PR DESCRIPTION
Fixes #74 

As I'm new to dry-types, I have very little overview if this could have negative impact elsewhere.