### PR TITLE
make Dry::Types::Enum inherit from BasicObject

### DIFF
--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -2,7 +2,7 @@ require 'dry/types/decorator'
 
 module Dry
   module Types
-    class Enum
+    class Enum < BasicObject
       include Decorator
 
       attr_reader :values, :mapping

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -56,5 +56,24 @@ RSpec.describe Dry::Types::Array do
         expect(john.name).to eql('John')
       end
     end
+
+    context 'enum' do
+      it 'uses enum type for member values' do
+        enum = Dry::Types['strict.string'].enum(*%w(draft published archived))
+        array = Dry::Types['array'].member(enum)
+
+        expect{ array[['draft', 'published']] }.to_not raise_error
+        expect{ array[['trash', 'published']] }.to raise_error(Dry::Types::ConstraintError)
+      end
+      it 'uses enum type for member values if Object was monkeypatched' do
+        Object.send(:define_method, :try){|*| nil}
+
+        enum = Dry::Types['strict.string'].enum(*%w(draft published archived))
+        array = Dry::Types['strict.array'].member(enum)
+
+        expect{ array[['draft', 'published']] }.to_not raise_error
+        Object.send(:remove_method, :try)
+      end
+    end
   end
 end


### PR DESCRIPTION
as further discussion base to fix the issues described in #78 

As @timriley suggested I quickly tried using `BasicObject` for the other 5 classes which mixin `Decorator`.
In all cases the specs start to fail in - lets say interesting - manner. But I didn't dig further into it.