### PR TITLE
Let Form::Date[nil] return nil

### DIFF
--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -8,6 +8,8 @@ module Dry
       end
 
       def to_date(input)
+        return nil if input.nil?
+
         Date.parse(input)
       rescue ArgumentError
         input

--- a/spec/dry/types/types/form_spec.rb
+++ b/spec/dry/types/types/form_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Dry::Types::Definition do
     it 'returns original value when it was unparsable' do
       expect(type['not-a-date']).to eql('not-a-date')
     end
+
+    it 'returns nil when given nil' do
+      expect(type[nil]).to eql(nil)
+    end
   end
 
   describe 'form.date_time' do


### PR DESCRIPTION
`Date.parse(nil)` raises a `TypeError`, so handle that case explicitly.
I could've rescued from `TypeError`, but that would allow for
`Form::Date[2]` to return `2`. That's probably not how form coercions should
behave.

This fixes #83.