### PR TITLE
Coerce empty strings in form posts to blank arrays and hashes

### DIFF
--- a/lib/dry/types/coercions/form.rb
+++ b/lib/dry/types/coercions/form.rb
@@ -52,6 +52,14 @@ module Dry
             result
           end
         end
+
+        def self.to_ary(input)
+          empty_str?(input) ? [] : input
+        end
+
+        def self.to_hash(input)
+          empty_str?(input) ? {} : input
+        end
       end
     end
   end

--- a/lib/dry/types/form.rb
+++ b/lib/dry/types/form.rb
@@ -43,11 +43,11 @@ module Dry
     end
 
     register('form.array') do
-      self['array'].safe
+      self['array'].safe.constructor(Coercions::Form.method(:to_ary))
     end
 
     register('form.hash') do
-      self['hash'].safe
+      self['hash'].safe.constructor(Coercions::Form.method(:to_hash))
     end
   end
 end

--- a/spec/dry/types/types/form_spec.rb
+++ b/spec/dry/types/types/form_spec.rb
@@ -173,6 +173,11 @@ RSpec.describe Dry::Types::Definition do
       expect(type[arr]).to eql([1, 2, 3])
     end
 
+    it 'coerces an empty string into an empty array' do
+      input = ''
+      expect(type[input]).to eql([])
+    end
+
     it 'returns original value when it is not an array' do
       foo = 'foo'
       expect(type[foo]).to be(foo)
@@ -185,6 +190,11 @@ RSpec.describe Dry::Types::Definition do
     it 'returns coerced hash' do
       hash = { age: '21' }
       expect(type[hash]).to eql(age: 21)
+    end
+
+    it 'coerces an empty string into an empty hash' do
+      input = ''
+      expect(type[input]).to eql({})
     end
 
     it 'returns original value when it is not an hash' do


### PR DESCRIPTION
This change makes it possible for forms to post blank arrays and hashes when the form post corresponds to dry-validation schema keys that are typed as arrays and hashes. You can do this with blank hidden inputs in your form, e.g.

```html
<input name="some_array" type="hidden">
<input name="some_hash" type="hidden">
```

Corresponding to a schema like this (from dry-validation master):

```ruby
Dry::Valiation.Form do
  required(:some_array).each(:str?)
  required(:some_hash).value(:hash?)
end
```

When this form is posted, these hidden inputs would come through as empty strings, which these new coercions will now turn into proper empty arrays and hashes.

This is useful because there is otherwise no way to signify in a form post that an array or hash value should be specified, but _empty_ (i.e. if you want your form post to indicate that some array- or hash-type value has been _cleared out_ by the user). If the `some_array` and `some_hash` form keys (from the example above) were completely absent, then this is a different meaning: that those keys were not included in this form, and therefore were probably not changed.

This change is necessary for our [formalist-standard-react](https://github.com/icelab/formalist-standard-react) form builder to be able to post empty arrays and hashes in its forms (which by convention we process via dry-validation form schemas).

Resolves #76.

Also relates to https://github.com/dry-rb/dry-validation/issues/102, and would effectively solve this issue for us too.

