### PR TITLE
Dry logic predicate change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,3 +20,5 @@ group :benchmarks do
   gem 'fast_attributes'
   gem 'attrio'
 end
+
+gem "dry-logic", path: "../dry-logic"

--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,4 @@ group :benchmarks do
   gem 'attrio'
 end
 
-gem "dry-logic", path: "../dry-logic"
+gem "dry-logic", git: 'https://github.com/dry-rb/dry-logic.git', branch: "master"

--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -33,7 +33,7 @@ module Dry
       end
 
       def enum(*values)
-        Enum.new(constrained(inclusion: values), values: values)
+        Enum.new(constrained(included_in: values), values: values)
       end
 
       def safe


### PR DESCRIPTION
This update makes use of the new predicate names from Dry-Logic

inclusion to included_in and exclusion to excluded_from.