### PR TITLE
Coerce nil values in form to blank arrays and hashes

### DIFF
--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -30,6 +30,10 @@ module Dry
       def empty_str?(value)
         EMPTY_STRING.eql?(value)
       end
+
+      def empty?(value)
+        value.nil? || empty_str?(value)
+      end
     end
   end
 end

--- a/lib/dry/types/coercions/form.rb
+++ b/lib/dry/types/coercions/form.rb
@@ -50,11 +50,11 @@ module Dry
         end
 
         def self.to_ary(input)
-          empty_str?(input) ? [] : input
+          empty?(input) ? [] : input
         end
 
         def self.to_hash(input)
-          empty_str?(input) ? {} : input
+          empty?(input) ? {} : input
         end
       end
     end

--- a/spec/dry/types/types/form_spec.rb
+++ b/spec/dry/types/types/form_spec.rb
@@ -192,6 +192,11 @@ RSpec.describe Dry::Types::Definition do
       expect(type[input]).to eql([])
     end
 
+    it 'coerces nil into an empty array' do
+      input = nil
+      expect(type[input]).to eql([])
+    end
+
     it 'returns original value when it is not an array' do
       foo = 'foo'
       expect(type[foo]).to be(foo)
@@ -208,6 +213,11 @@ RSpec.describe Dry::Types::Definition do
 
     it 'coerces an empty string into an empty hash' do
       input = ''
+      expect(type[input]).to eql({})
+    end
+
+    it 'coerces nil into an empty hash' do
+      input = nil
       expect(type[input]).to eql({})
     end
 


### PR DESCRIPTION
Basically the same thing as #88, but for nil values.

review @timriley @flash-gordon
