### PR TITLE
Make Struct#to_hash go through arrays

### DIFF
--- a/lib/dry/types/hashify.rb
+++ b/lib/dry/types/hashify.rb
@@ -1,20 +1,12 @@
 # Converts value to hash recursively
-class Hashify
+module Hashify
   def self.[](value)
-    new(value).call
-  end
-
-  def initialize(value)
-    @value = value
-  end
-
-  def call
-    if @value.respond_to?(:to_hash)
-      @value.to_hash
-    elsif @value.respond_to?(:map)
-      @value.map { |item| self.class[item] }
+    if value.respond_to?(:to_hash)
+      value.to_hash
+    elsif value.respond_to?(:map)
+      value.map { |item| self[item] }
     else
-      @value
+      value
     end
   end
 end

--- a/lib/dry/types/hashify.rb
+++ b/lib/dry/types/hashify.rb
@@ -1,0 +1,20 @@
+# Converts value to hash recursively
+class Hashify
+  def self.[](value)
+    new(value).call
+  end
+
+  def initialize(value)
+    @value = value
+  end
+
+  def call
+    if @value.respond_to?(:to_hash)
+      @value.to_hash
+    elsif @value.respond_to?(:map)
+      @value.map { |item| self.class[item] }
+    else
+      @value
+    end
+  end
+end

--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -1,3 +1,5 @@
+require_relative 'hashify'
+
 module Dry
   module Types
     class Struct
@@ -87,10 +89,9 @@ module Dry
       end
 
       def to_hash
-        self.class.schema.keys.each_with_object({}) { |key, result|
-          value = self[key]
-          result[key] = value.respond_to?(:to_hash) ? value.to_hash : value
-        }
+        self.class.schema.keys.each_with_object({}) do |key, result|
+          result[key] = Hashify[self[key]]
+        end
       end
       alias_method :to_h, :to_hash
     end

--- a/spec/dry/types/struct_spec.rb
+++ b/spec/dry/types/struct_spec.rb
@@ -183,12 +183,27 @@ RSpec.describe Dry::Types::Struct do
   end
 
   describe '#to_hash' do
+    let(:parent_type) { Dry::Types["test.parent"] }
+
+    before do
+      module Test
+        class Parent < User
+          attribute :children, Dry::Types["coercible.array"].member("test.user")
+        end
+      end
+    end
+
     it 'returns hash with attributes' do
-      attributes = {
-        name: 'Jane', age: 21, address: { city: 'NYC', zipcode: '123' }
+      attributes  = {
+        name: 'Jane',
+        age:  29,
+        address: { city: 'NYC', zipcode: '123' },
+        children: [
+          { name: 'Joe', age: 3, address: { city: 'NYC', zipcode: '123' } }
+        ]
       }
 
-      expect(user_type[attributes].to_hash).to eql(attributes)
+      expect(parent_type[attributes].to_hash).to eql(attributes)
     end
   end
 end


### PR DESCRIPTION
`Struct#to_hash` hashifies stuctures deeper (going inside arrays).

Suppose a struct has array attributes with struct members:
```
class User < Dry::Types::Struct
  attribute :name, Types::Coercible::String
end

class Parent < User
  attribute :children, Types::Array.member('user')
end

attributes = { name: 'Joe', children: [{ name: 'Jane' }] }
parent = Parent.new(attributes)
```
Old behaviour:
```
parent.to_hash # => { name: 'Joe', children: [#<User name="Jane">] }
```
New behaviour:
```
parent.to_hash # => { name: 'Joe', children: [{ name: 'Jane' }] }
```