### PR TITLE
Make Struct work as a type definition

### DIFF
--- a/lib/dry/types/struct.rb
+++ b/lib/dry/types/struct.rb
@@ -1,84 +1,10 @@
 require_relative 'hashify'
+require 'dry/types/struct/class_interface'
 
 module Dry
   module Types
     class Struct
-      class << self
-        attr_reader :constructor
-      end
-
-      def self.inherited(klass)
-        super
-
-        klass.instance_variable_set('@equalizer', Equalizer.new(*schema.keys))
-        klass.instance_variable_set('@constructor_type', constructor_type)
-        klass.send(:include, klass.equalizer)
-
-        unless klass == Value
-          klass.instance_variable_set('@constructor', Types['coercible.hash'])
-          Types.register_class(klass)
-        end
-
-        klass.attributes({}) unless equal?(Struct)
-      end
-
-      def self.equalizer
-        @equalizer
-      end
-
-      def self.attribute(name, type)
-        attributes(name => type)
-      end
-
-      def self.attributes(new_schema)
-        check_schema_duplication(new_schema)
-
-        prev_schema = schema
-
-        @schema = prev_schema.merge(new_schema)
-        @constructor = Types['coercible.hash'].public_send(constructor_type, schema)
-
-        attr_reader(*new_schema.keys)
-        equalizer.instance_variable_get('@keys').concat(new_schema.keys)
-
-        self
-      end
-
-      def self.check_schema_duplication(new_schema)
-        shared_keys = new_schema.keys & schema.keys
-
-        fail RepeatedAttributeError, shared_keys.first if shared_keys.any?
-      end
-      private_class_method :check_schema_duplication
-
-      def self.constructor_type(type = nil)
-        if type
-          @constructor_type = type
-        else
-          @constructor_type || :strict
-        end
-      end
-
-      def self.schema
-        super_schema = superclass.respond_to?(:schema) ? superclass.schema : {}
-        super_schema.merge(@schema || {})
-      end
-
-      def self.new(attributes = default_attributes)
-        if attributes.instance_of?(self)
-          attributes
-        else
-          super(constructor[attributes])
-        end
-      rescue SchemaError, SchemaKeyError => error
-        raise StructError, "[#{self}.new] #{error}"
-      end
-
-      def self.default_attributes
-        schema.each_with_object({}) { |(name, type), result|
-          result[name] = type.default? ? type.evaluate : type[nil]
-        }
-      end
+      extend ClassInterface
 
       def initialize(attributes)
         attributes.each { |key, value| instance_variable_set("@#{key}", value) }

--- a/lib/dry/types/struct/class_interface.rb
+++ b/lib/dry/types/struct/class_interface.rb
@@ -1,0 +1,107 @@
+module Dry
+  module Types
+    class Struct
+      module ClassInterface
+        include Builder
+
+        attr_accessor :constructor
+
+        attr_accessor :equalizer
+
+        attr_writer :constructor_type
+
+        protected :constructor=, :equalizer=, :constructor_type=
+
+        def inherited(klass)
+          super
+
+          klass.equalizer = Equalizer.new(*schema.keys)
+          klass.constructor_type = constructor_type
+          klass.send(:include, klass.equalizer)
+
+          unless klass == Value
+            klass.constructor = Types['coercible.hash']
+            Types.register(Types.identifier(klass), klass)
+          end
+
+          klass.attributes({}) unless equal?(Struct)
+        end
+
+        def attribute(name, type)
+          attributes(name => type)
+        end
+
+        def attributes(new_schema)
+          check_schema_duplication(new_schema)
+
+          prev_schema = schema
+
+          @schema = prev_schema.merge(new_schema)
+          @constructor = Types['coercible.hash'].public_send(constructor_type, schema)
+
+          attr_reader(*new_schema.keys)
+          equalizer.instance_variable_get('@keys').concat(new_schema.keys)
+
+          self
+        end
+
+        def check_schema_duplication(new_schema)
+          shared_keys = new_schema.keys & schema.keys
+
+          fail RepeatedAttributeError, shared_keys.first if shared_keys.any?
+        end
+        private :check_schema_duplication
+
+        def constructor_type(type = nil)
+          if type
+            @constructor_type = type
+          else
+            @constructor_type || :strict
+          end
+        end
+
+        def schema
+          super_schema = superclass.respond_to?(:schema) ? superclass.schema : {}
+          super_schema.merge(@schema || {})
+        end
+
+        def new(attributes = default_attributes)
+          if attributes.instance_of?(self)
+            attributes
+          else
+            super(constructor[attributes])
+          end
+        rescue SchemaError, SchemaKeyError => error
+          raise StructError, "[#{self}.new] #{error}"
+        end
+        alias_method :call, :new
+        alias_method :[], :new
+
+        def default_attributes
+          schema.each_with_object({}) { |(name, type), result|
+            result[name] = type.default? ? type.evaluate : type[nil]
+          }
+        end
+
+        def try(input)
+          Result::Success.new(self[input])
+        rescue StructError => e
+          failure = Result::Failure.new(input, e.message)
+          block_given? ? yield(failure) : failure
+        end
+
+        def maybe?
+          false
+        end
+
+        def default?
+          false
+        end
+
+        def valid?(value)
+          self === value
+        end
+      end
+    end
+  end
+end

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -55,7 +55,7 @@ RSpec.shared_examples_for Dry::Types::Struct do
 
   context 'class interface' do
     describe '.|' do
-      let(:sum_type) { type_or_nil = type | Dry::Types['strict.nil'] }
+      let(:sum_type) { type | Dry::Types['strict.nil'] }
 
       it 'returns Sum type' do
         expect(sum_type).to be_instance_of(Dry::Types::Sum)

--- a/spec/shared/struct.rb
+++ b/spec/shared/struct.rb
@@ -1,17 +1,12 @@
 RSpec.shared_examples_for Dry::Types::Struct do
+  let(:jane) { { name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 } } }
+  let(:mike) { { name: :Mike, age: '43', root: false, address: { city: 'Atlantis', zipcode: 456 } } }
+  let(:john) { { name: :John, age: '36', root: false, address: { city: 'San Francisco', zipcode: 789 } } }
+
   describe '#eql' do
     context 'when struct values are equal' do
-      let(:user_1) do
-        type[
-          name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
-        ]
-      end
-
-      let(:user_2) do
-        type[
-          name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
-        ]
-      end
+      let(:user_1) { type[jane] }
+      let(:user_2) { type[jane] }
 
       it 'returns true' do
         expect(user_1).to eql(user_2)
@@ -19,17 +14,8 @@ RSpec.shared_examples_for Dry::Types::Struct do
     end
 
     context 'when struct values are not equal' do
-      let(:user_1) do
-        type[
-          name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
-        ]
-      end
-
-      let(:user_2) do
-        type[
-          name: :Mike, age: '43', root: false, address: { city: 'Atlantis', zipcode: 456 }
-        ]
-      end
+      let(:user_1) { type[jane] }
+      let(:user_2) { type[mike] }
 
       it 'returns false' do
         expect(user_1).to_not eql(user_2)
@@ -39,17 +25,8 @@ RSpec.shared_examples_for Dry::Types::Struct do
 
   describe '#hash' do
     context 'when struct values are equal' do
-      let(:user_1) do
-        type[
-          name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
-        ]
-      end
-
-      let(:user_2) do
-        type[
-          name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
-        ]
-      end
+      let(:user_1) { type[jane] }
+      let(:user_2) { type[jane] }
 
       it 'the hashes are equal' do
         expect(user_1.hash).to eql(user_2.hash)
@@ -57,17 +34,8 @@ RSpec.shared_examples_for Dry::Types::Struct do
     end
 
     context 'when struct values are not equal' do
-      let(:user_1) do
-        type[
-          name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
-        ]
-      end
-
-      let(:user_2) do
-        type[
-          name: :Mike, age: '43', root: false, address: { city: 'Atlantis', zipcode: 456 }
-        ]
-      end
+      let(:user_1) { type[jane] }
+      let(:user_2) { type[mike] }
 
       it 'the hashes are not equal' do
         expect(user_1.hash).to_not eql(user_2.hash)
@@ -76,16 +44,68 @@ RSpec.shared_examples_for Dry::Types::Struct do
   end
 
   describe '#inspect' do
-    let(:user_1) do
-      type[
-        name: :Jane, age: '21', root: true, address: { city: 'NYC', zipcode: 123 }
-      ]
-    end
+    let(:user_1) { type[jane] }
 
     it 'lists attributes' do
       expect(user_1.inspect).to eql(
-        %Q(#<#{type.primitive} name="Jane" age=21 address=#<Test::Address city="NYC" zipcode="123"> root=true>)
+        %Q(#<#{type} name="Jane" age=21 address=#<Test::Address city="NYC" zipcode="123"> root=true>)
       )
     end
+  end
+
+  context 'class interface' do
+    describe '.|' do
+      let(:sum_type) { type_or_nil = type | Dry::Types['strict.nil'] }
+
+      it 'returns Sum type' do
+        expect(sum_type).to be_instance_of(Dry::Types::Sum)
+        expect(sum_type[nil]).to be_nil
+        expect(sum_type[jane]).to eql(type[jane])
+      end
+    end
+
+    describe '.maybe?' do
+      it 'is not a maybe' do
+        expect(type).not_to be_maybe
+      end
+    end
+
+    describe '.default?' do
+      it 'is not a default' do
+        expect(type).not_to be_default
+      end
+    end
+
+    describe '.default' do
+      let(:default_type) { type.default(type[jane]) }
+
+      it 'retruns Default type' do
+        expect(default_type).to be_instance_of(Dry::Types::Default)
+        expect(default_type[nil]).to eql(type[jane])
+      end
+    end
+
+    describe '.enum' do
+      let(:enum_type) { type.enum(type[jane], type[mike]) }
+
+      it 'returns Enum type' do
+        expect(enum_type[type[jane]]).to eql(type[jane])
+        expect { enum_type[type[john]] }.to raise_error(Dry::Types::ConstraintError)
+      end
+    end
+
+    describe '.optional' do
+      let(:optional_type) { type.optional }
+
+      it 'returns Sum type' do
+        expect(optional_type).to eql(Dry::Types['strict.nil'] | type)
+        expect(optional_type[nil]).to be_nil
+        expect(optional_type[jane]).to eql(type[jane])
+      end
+    end
+  end
+
+  it 'registered without wrapping' do
+    expect(Dry::Types[type]).to be type
   end
 end


### PR DESCRIPTION
This add an interface of a type definition to Struct and Value and makes them work with `.|`, `.default`, `.enum`, and `.optional` methods for building new types. This is became a frequently requested feature and as far as I can tell nothing stops us from supporting it. A noticeable change is that Struct/Value subclasses are now registered in the container as is, we don't need to wrap them with a type definition anymore.
Any thoughts? /cc @solnic @AMHOL @timriley 