### PR TITLE
Fix #with behavior with Default/Callable types

### DIFF
--- a/lib/dry/types/decorator.rb
+++ b/lib/dry/types/decorator.rb
@@ -1,11 +1,15 @@
+require 'dry/types/options'
+
 module Dry
   module Types
     module Decorator
-      attr_reader :type, :options
+      include Options
 
-      def initialize(type, options = {})
+      attr_reader :type
+
+      def initialize(type, *)
+        super
         @type = type
-        @options = options
       end
 
       def constructor
@@ -14,10 +18,6 @@ module Dry
 
       def try(input, &block)
         type.try(input, &block)
-      end
-
-      def with(new_options)
-        self.class.new(type, options.merge(new_options))
       end
 
       def valid?(value)

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -27,8 +27,8 @@ module Dry
         end
       end
 
-      def initialize(type, value, options = {})
-        super(type, options)
+      def initialize(type, value, *)
+        super
         @value = value
       end
 

--- a/lib/dry/types/options.rb
+++ b/lib/dry/types/options.rb
@@ -5,7 +5,7 @@ module Dry
 
       attr_reader :meta
 
-      def initialize(*args, **options )
+      def initialize(*args, **options)
         @__args__ = args
         @options = options
         @meta = options.fetch(:meta, {})

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -90,4 +90,17 @@ RSpec.describe Dry::Types::Definition, '#default' do
       it_behaves_like 'a type with equality defined'
     end
   end
+
+  describe'#with' do
+    subject(:type) { Dry::Types['time'].default { Time.now }.with(meta: { foo: :bar }) }
+
+    it 'creates a new type with provided options' do
+      expect(type.options).to eql(meta: { foo: :bar })
+      expect(type.meta).to eql(foo: :bar)
+    end
+
+    it 'calls the value' do
+      expect(type[nil]).to be_instance_of(Time)
+    end
+  end
 end

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -84,4 +84,12 @@ RSpec.describe Dry::Types::Enum do
       expect(enum.try(2) { 5 }).to be(5)
     end
   end
+
+  describe '#with' do
+    subject(:enum_with_meta) { Dry::Types['int'].enum(4, 5, 6).with(meta: { foo: :bar }) }
+
+    it 'preserves metadata' do
+      expect(enum_with_meta.meta).to eql(foo: :bar)
+    end
+  end
 end


### PR DESCRIPTION
Now Default type works nice with ROM's schema attribute which calls
`#with` on a passed type.

This also fixes the issue when a decorator type cannot have metadata.
