### PR TITLE
Improve dry/types_spec.rb

### DIFF
--- a/spec/dry/types_spec.rb
+++ b/spec/dry/types_spec.rb
@@ -29,6 +29,9 @@ RSpec.describe Dry::Types do
       Dry::Types.register_class(Test::User)
 
       expect(Dry::Types['test.user'].primitive).to be(Test::User)
+
+      user = Dry::Types['test.user']['jane']
+      expect(user.name).to eql('jane')
     end
 
     it 'registers a class and uses a custom constructor method' do

--- a/spec/dry/types_spec.rb
+++ b/spec/dry/types_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Dry::Types do
   describe '.register' do
     it 'registers a new type constructor' do
-      class FlatArray
+      module FlatArray
         def self.constructor(input)
           input.flatten
         end

--- a/spec/dry/types_spec.rb
+++ b/spec/dry/types_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dry::Types do
       module Test
         User = Struct.new(:name) do
           def self.build(name)
-            new(name.to_s)
+            new(name.upcase)
           end
         end
       end
@@ -47,8 +47,8 @@ RSpec.describe Dry::Types do
 
       expect(Dry::Types['test.user'].primitive).to be(Test::User)
 
-      user = Dry::Types['test.user'][:jane]
-      expect(user.name).to eql('jane')
+      user = Dry::Types['test.user']['jane']
+      expect(user.name).to eql('JANE')
     end
   end
 

--- a/spec/dry/types_spec.rb
+++ b/spec/dry/types_spec.rb
@@ -21,11 +21,17 @@ RSpec.describe Dry::Types do
   end
 
   describe '.register_class' do
-    it 'registers a class and uses `.new` method as default constructor' do
+    before do
       module Test
-        User = Struct.new(:name)
+        User = Struct.new(:name) do
+          def self.build(name)
+            new(name.upcase)
+          end
+        end
       end
+    end
 
+    it 'registers a class and uses `.new` method as default constructor' do
       Dry::Types.register_class(Test::User)
 
       expect(Dry::Types['test.user'].primitive).to be(Test::User)
@@ -35,14 +41,6 @@ RSpec.describe Dry::Types do
     end
 
     it 'registers a class and uses a custom constructor method' do
-      module Test
-        User = Struct.new(:name) do
-          def self.build(name)
-            new(name.upcase)
-          end
-        end
-      end
-
       Dry::Types.register_class(Test::User, :build)
 
       expect(Dry::Types['test.user'].primitive).to be(Test::User)


### PR DESCRIPTION
This PR tries to make a clear distinction of a constructor that calls the default _new_ methods and a constructor that calls a custom method (ex: build) differentiating them with a plain and an upcased result.