### PR TITLE
Improve form boolean casting

### DIFF
--- a/lib/dry/types/coercions/form.rb
+++ b/lib/dry/types/coercions/form.rb
@@ -12,11 +12,11 @@ module Dry
         extend Coercions
 
         def self.to_true(input)
-          BOOLEAN_MAP.fetch(input, input)
+          BOOLEAN_MAP.fetch(input.to_s, input)
         end
 
         def self.to_false(input)
-          BOOLEAN_MAP.fetch(input, input)
+          BOOLEAN_MAP.fetch(input.to_s, input)
         end
 
         def self.to_int(input)

--- a/lib/dry/types/coercions/form.rb
+++ b/lib/dry/types/coercions/form.rb
@@ -5,8 +5,8 @@ module Dry
   module Types
     module Coercions
       module Form
-        TRUE_VALUES = %w[1 on On ON t true True TRUE  y yes Yes YES].freeze
-        FALSE_VALUES = %w[0 off Off OFF f false False FALSE n no No NO].freeze
+        TRUE_VALUES = %w[1 on On ON t true True TRUE T y yes Yes YES].freeze
+        FALSE_VALUES = %w[0 off Off OFF f false False FALSE F n no No NO].freeze
         BOOLEAN_MAP = ::Hash[TRUE_VALUES.product([true]) + FALSE_VALUES.product([false])].freeze
 
         extend Coercions

--- a/spec/dry/types/types/form_spec.rb
+++ b/spec/dry/types/types/form_spec.rb
@@ -67,13 +67,13 @@ RSpec.describe Dry::Types::Definition do
     subject(:type) { Dry::Types['form.bool'] }
 
     it 'coerces to true' do
-      %w[1 on  t true  y yes].each do |value|
+      %w[1 on T t true  y yes] + [1].each do |value|
         expect(type[value]).to be(true)
       end
     end
 
     it 'coerces to false' do
-      %w[0 off f false n no].each do |value|
+      %w[0 off F f false n no] + [0].each do |value|
         expect(type[value]).to be(false)
       end
     end


### PR DESCRIPTION
* typecast `T` and `F` to boolean values (before we only accepted `t` and `f`)
* stringify boolean input values before passing them to map

The second thing may sound like it's not the case for `Form`, but here is my use case:

`Dry::Validation.Form` receives input from JSON parsed by Rails.
The clients sends the following JSON:
```json
{ "accept_the_rules": 0 }
```

which will be parsed by Rails JSON parser to

```ruby
{ "accept_the_rules" => 0 }
```

And `Dry::Validation.Form` will receive the integer value that it will try to typecast to boolean.

@solnic what do you think?