### PR TITLE
Rename Hash#strict to Hash#permissive

### DIFF
--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -19,8 +19,8 @@ module Dry
         schema(type_map, Weak)
       end
 
-      def strict(type_map)
-        schema(type_map, Strict)
+      def permissive(type_map)
+        schema(type_map, Permissive)
       end
 
       def symbolized(type_map)

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -43,7 +43,7 @@ module Dry
         end
       end
 
-      class Strict < Schema
+      class Permissive < Schema
         def call(hash, meth = :call)
           member_types.each_with_object({}) do |(key, type), result|
             begin

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     ast = [
       :type, [
         'hash', [
-          :strict, [
+          :permissive, [
             [:key, [:email, [:type, 'string']]],
             [:key, [:age, [:type, 'form.int']]],
             [:key, [:admin, [:type, 'form.bool']]],
             [:key, [:address, [
               :type, [
                 'hash', [
-                  :strict, [
+                  :permissive, [
                     [:key, [:city, [:type, 'string']]],
                     [:key, [:street, [:type, 'string']]]
                   ]
@@ -28,7 +28,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
 
     hash = compiler.(ast)
 
-    expect(hash).to be_instance_of(Dry::Types::Hash::Strict)
+    expect(hash).to be_instance_of(Dry::Types::Hash::Permissive)
 
     result = hash[
       email: 'jane@doe.org',

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dry::Types::Hash do
 
   describe '#[]' do
     subject(:hash) do
-      Dry::Types['coercible.hash'].strict(
+      Dry::Types['coercible.hash'].permissive(
         name: "coercible.string",
         age: "coercible.int",
         active: "strict.bool",


### PR DESCRIPTION
As part of the planned `constructor_type` transition the `strict`
schema is being renamed to `permissive` to make room for a more
strict schema type.

See: https://gitter.im/dry-rb/chat?at=57686358feaf6cd222ad7e15

Also from gitter:

> @backus proposal looks good except :permissive which shouldn’t use defaults, so I just want it to work exactly the same as current :strict - this is really important for the common case of building structs from db data that you expect to be valid