### PR TITLE
Graceful form types

### DIFF
--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -8,20 +8,23 @@ module Dry
       end
 
       def to_date(input)
+        return input unless input.respond_to?(:to_str)
         Date.parse(input)
-      rescue ArgumentError, TypeError
+      rescue ArgumentError
         input
       end
 
       def to_date_time(input)
+        return input unless input.respond_to?(:to_str)
         DateTime.parse(input)
-      rescue ArgumentError, TypeError
+      rescue ArgumentError
         input
       end
 
       def to_time(input)
+        return input unless input.respond_to?(:to_str)
         Time.parse(input)
-      rescue ArgumentError, TypeError
+      rescue ArgumentError
         input
       end
 

--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -9,19 +9,19 @@ module Dry
 
       def to_date(input)
         Date.parse(input)
-      rescue ArgumentError
+      rescue ArgumentError, TypeError
         input
       end
 
       def to_date_time(input)
         DateTime.parse(input)
-      rescue ArgumentError
+      rescue ArgumentError, TypeError
         input
       end
 
       def to_time(input)
         Time.parse(input)
-      rescue ArgumentError
+      rescue ArgumentError, TypeError
         input
       end
 

--- a/spec/dry/types/types/form_spec.rb
+++ b/spec/dry/types/types/form_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Dry::Types::Definition do
     it 'returns original value when it was unparsable' do
       expect(type['not-a-date']).to eql('not-a-date')
     end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
+    end
   end
 
   describe 'form.date_time' do
@@ -49,6 +54,11 @@ RSpec.describe Dry::Types::Definition do
     it 'returns original value when it was unparsable' do
       expect(type['not-a-date-time']).to eql('not-a-date-time')
     end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
+    end
   end
 
   describe 'form.time' do
@@ -60,6 +70,11 @@ RSpec.describe Dry::Types::Definition do
 
     it 'returns original value when it was unparsable' do
       expect(type['not-a-time']).to eql('not-a-time')
+    end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
     end
   end
 

--- a/spec/dry/types/types/form_spec.rb
+++ b/spec/dry/types/types/form_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Dry::Types::Definition do
     it 'returns original value when it is not an empty string' do
       expect(type[['foo']]).to eql(['foo'])
     end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
+    end
   end
 
   describe 'form.nil | form.int' do
@@ -96,6 +101,11 @@ RSpec.describe Dry::Types::Definition do
     it 'returns original value when it is not supported' do
       expect(type['huh?']).to eql('huh?')
     end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
+    end
   end
 
   describe 'form.true' do
@@ -110,6 +120,11 @@ RSpec.describe Dry::Types::Definition do
     it 'returns original value when it is not supported' do
       expect(type['huh?']).to eql('huh?')
     end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
+    end
   end
 
   describe 'form.false' do
@@ -123,6 +138,11 @@ RSpec.describe Dry::Types::Definition do
 
     it 'returns original value when it is not supported' do
       expect(type['huh?']).to eql('huh?')
+    end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
     end
   end
 
@@ -142,6 +162,11 @@ RSpec.describe Dry::Types::Definition do
       expect(type['foo']).to eql('foo')
       expect(type['23asd']).to eql('23asd')
       expect(type[{}]).to eql({})
+    end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
     end
   end
 
@@ -165,6 +190,11 @@ RSpec.describe Dry::Types::Definition do
       expect(type['foo']).to eql('foo')
       expect(type['23asd']).to eql('23asd')
       expect(type[{}]).to eql({})
+    end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
     end
   end
 
@@ -192,6 +222,11 @@ RSpec.describe Dry::Types::Definition do
     it 'coerces Float to BigDecimal without complaining about precision' do
       expect(type[3.12]).to eql(BigDecimal('3.12'))
     end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
+    end
   end
 
   describe 'form.array' do
@@ -211,6 +246,11 @@ RSpec.describe Dry::Types::Definition do
       foo = 'foo'
       expect(type[foo]).to be(foo)
     end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
+    end
   end
 
   describe 'form.hash' do
@@ -229,6 +269,11 @@ RSpec.describe Dry::Types::Definition do
     it 'returns original value when it is not an hash' do
       foo = 'foo'
       expect(type[foo]).to be(foo)
+    end
+
+    it 'returns original value when it is not a string' do
+      object = Object.new
+      expect(type[object]).to eql(object)
     end
   end
 end


### PR DESCRIPTION
Addresses the issues (but does not fix) in #129.

I added some specs for other form types as well, in order to ensure they keep failing gracefully in the future. One odd thing I experienced is that adding a similar test to the `form.nil | form.int` check will raise an error, so I left it out for now:

```
Failures:

  1) Dry::Types::Definition form.nil | form.int returns original value when it is not a string
     Failure/Error: raise ConstraintError, result

     Dry::Types::ConstraintError:
       #<Object:0x007f8b7d5414a0> violates constraints (#<Dry::Types::Result::Failure input=#<Object:0x007f8b7d5414a0> error="#<Object:0x007f8b7d5414a0> must be an instance of Integer">)
     # ./lib/dry/types/sum.rb:48:in `block in call'
     # ./lib/dry/types/sum.rb:61:in `try'
     # ./lib/dry/types/sum.rb:47:in `call'
     # ./spec/dry/types/types/form_spec.rb:32:in `block (3 levels) in <top (required)>'
```

I assume this has to do with the way sum types check the validity. Maybe the validity check needs to be adjusted for form types? If this is something you would like me to tackle I'd be happy to try it, but I would probably need a few pointers in the right direction first.