### PR TITLE
Remove jruby-head from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ env:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-head
-  include:
-    - rvm: jruby-head
-      before_install: gem install bundler --no-ri --no-rdoc
 notifications:
   email: false
   webhooks:


### PR DESCRIPTION
> John Backus @backus Aug 30 16:26
> :skull: <-- me waiting for jruby-head to finish on CI
>
> Piotr Solnica @solnic Aug 30 16:32
> @backus I’d vote for removing jruby-head from all builds
> it’s been killing me too
>
> ...
>
> Tim Riley @timriley Aug 30 18:32
> oh yes, definitely +1 to removing jruby-head

