### PR TITLE
Add `strict_with_defaults` constructor

### DIFF
--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -27,6 +27,10 @@ module Dry
         schema(type_map, Strict)
       end
 
+      def strict_with_defaults(type_map)
+        schema(type_map, StrictWithDefaults)
+      end
+
       def symbolized(type_map)
         schema(type_map, Symbolized)
       end

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -78,6 +78,29 @@ module Dry
         alias_method :[], :call
       end
 
+      class StrictWithDefaults < Schema
+        def call(hash, meth = :call)
+          unexpected = hash.keys - member_types.keys
+          raise UnknownKeysError.new(*unexpected) unless unexpected.empty?
+
+          member_types.each_with_object({}) do |(key, type), result|
+            begin
+              value = hash.fetch(key)
+              result[key] = type.public_send(meth, value)
+            rescue TypeError
+              raise SchemaError.new(key, value)
+            rescue KeyError
+              if type.default?
+                result[key] = type.value
+              else
+                raise MissingKeyError.new(key)
+              end
+            end
+          end
+        end
+        alias_method :[], :call
+      end
+
       class Weak < Schema
         def self.new(primitive, options)
           member_types = options.

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -156,6 +156,17 @@ RSpec.describe Dry::Types::Hash do
     end
   end
 
+  shared_examples 'strict schema behavior for unexpected keys' do
+    it 'rejects unexpected keys' do
+      expected_input = { name: :Jane, age: 21, active: true, phone: ['1', '2'] }
+      unexpected_input = { gender: 'F', email: 'Jane@hotmail.biz' }
+
+      expect { hash.call(expected_input.merge(unexpected_input)) }
+        .to raise_error(Dry::Types::UnknownKeysError)
+        .with_message('unexpected keys [:gender, :email] in Hash input')
+    end
+  end
+
   describe '#schema' do
     let(:hash) { primitive.schema(hash_schema) }
 
@@ -214,14 +225,8 @@ RSpec.describe Dry::Types::Hash do
     include_examples 'hash schema behavior'
     include_examples 'strict schema behavior for missing keys'
     include_examples 'strict typing behavior'
+    include_examples 'strict schema behavior for unexpected keys'
+  end
 
-    it 'rejects unexpected keys' do
-      expected_input = { name: :Jane, age: 21, active: true, phone: ['1', '2'] }
-      unexpected_input = { gender: 'F', email: 'Jane@hotmail.biz' }
-
-      expect { hash.call(expected_input.merge(unexpected_input)) }
-        .to raise_error(Dry::Types::UnknownKeysError)
-        .with_message('unexpected keys [:gender, :email] in Hash input')
-    end
   end
 end

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -228,5 +228,13 @@ RSpec.describe Dry::Types::Hash do
     include_examples 'strict schema behavior for unexpected keys'
   end
 
+  describe '#strict_with_defaults' do
+    let(:hash) { primitive.strict_with_defaults(hash_schema) }
+
+    include_examples 'hash schema behavior'
+    include_examples 'strict schema behavior for missing keys'
+    include_examples 'strict typing behavior'
+    include_examples 'strict schema behavior for unexpected keys'
+    include_examples 'sets default value behavior when keys are omitted'
   end
 end


### PR DESCRIPTION
Following up on #134 and #135, this is the last of the constructor changes planned for dry-types for the sake of dry-struct. Just like the other PRs, see https://gitter.im/dry-rb/chat?at=57686358feaf6cd222ad7e15 as a reference for this work