### PR TITLE
Fix #schema constructor raising different error

### DIFF
--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -12,7 +12,12 @@ module Dry
         def call(hash, meth = :call)
           member_types.each_with_object({}) do |(key, type), result|
             if hash.key?(key)
-              result[key] = type.public_send(meth, hash.fetch(key))
+              begin
+                value = hash.fetch(key)
+                result[key] = type.public_send(meth, value)
+              rescue ConstraintError
+                raise SchemaError.new(key, value)
+              end
             else
               resolve_missing_value(result, key, type)
             end

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -173,13 +173,7 @@ RSpec.describe Dry::Types::Hash do
     include_examples 'hash schema behavior'
     include_examples 'weak schema behavior for missing keys'
     include_examples 'sets default value behavior when keys are omitted'
-
-    # This is essentially the same test as "strict typing behavior" but
-    # the error is different for some reason
-    it 'fails if any coercions are unsuccessful' do
-      expect { hash.call(name: :Jane, age: 'oops', active: true, phone: []) }
-        .to raise_error(Dry::Types::ConstraintError, /"oops" violates constraints/)
-    end
+    include_examples 'strict typing behavior'
   end
 
   describe '#weak' do


### PR DESCRIPTION
All other hash schemas raise `SchemaError` except for the `:schema` constructor type. This change resolves this discrepancy