### PR TITLE
Allow to explicitly pass mapping to enum

### DIFF
--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -33,7 +33,14 @@ module Dry
       end
 
       def enum(*values)
-        Enum.new(constrained(included_in: values), values: values)
+        mapping =
+          if values.length == 1 && values[0].is_a?(::Hash)
+            values[0]
+          else
+            ::Hash[values.zip(0...values.size)]
+          end
+
+        Enum.new(constrained(included_in: mapping.keys), mapping: mapping)
       end
 
       def safe

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -3,24 +3,24 @@ require 'dry/types/decorator'
 module Dry
   module Types
     class Enum
-      include Dry::Equalizer(:type, :options, :values)
+      include Dry::Equalizer(:type, :options, :mapping)
       include Decorator
 
       attr_reader :values, :mapping
 
       def initialize(type, options)
         super
-        @values = options.fetch(:values).freeze
+        @mapping = options.fetch(:mapping).freeze
+        @values = @mapping.keys.freeze
         @values.each(&:freeze)
-        @mapping = values.each_with_object({}) { |v, h| h[values.index(v)] = v }.freeze
       end
 
       def call(input)
         value =
-          if values.include?(input)
+          if mapping.key?(input)
             input
-          elsif mapping.key?(input)
-            mapping[input]
+          elsif mapping.values.include?(input)
+            mapping.index(input)
           end
 
         type[value || input]

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -1,4 +1,30 @@
 RSpec.describe Dry::Types::Enum do
+  context 'with mapping' do
+    subject(:type) { string.enum(mapping) }
+
+    let(:mapping) { {'draft' => 0, 'published' => 10, 'archived' => 20} }
+    let(:values) { mapping.keys }
+    let(:string) { Dry::Types['strict.string'] }
+
+    it_behaves_like Dry::Types::Definition
+
+    it 'allows defining an enum from a specific type' do
+      expect(type['draft']).to eql(mapping.index(0))
+      expect(type['published']).to eql(mapping.index(10))
+      expect(type['archived']).to eql(mapping.index(20))
+
+      expect(type[0]).to be(mapping.index(0))
+      expect(type[10]).to be(mapping.index(10))
+      expect(type[20]).to eql(mapping.index(20))
+
+      expect(type.mapping).to eql(mapping)
+
+      expect { type['oops'] }.to raise_error(Dry::Types::ConstraintError, /oops/)
+
+      expect(type.mapping).to be_frozen
+    end
+  end
+
   context 'with string type' do
     subject(:type) { string.enum(*values) }
 
@@ -12,8 +38,8 @@ RSpec.describe Dry::Types::Enum do
       expect(type['published']).to eql(values[1])
       expect(type['archived']).to eql(values[2])
 
-      expect(type[0]).to be(values[0])
-      expect(type[1]).to be(values[1])
+      expect(type[0]).to eql(values[0])
+      expect(type[1]).to eql(values[1])
       expect(type[2]).to eql(values[2])
 
       expect(type.values).to eql(values)


### PR DESCRIPTION
Allow to explicitly pass mapping between values and integer representation to enum. 

When working with legacy applications it may be useful to provide mapping between enum values and corresponding integer values.

``` ruby
Statuses = Types::Strict::String.enum('draft' => 0, 'published' => 10, 'archived' => 20)
Statuses[10] # => "published"
Statuses['published'] # => "published"
```

Passing values withot mapping works as well:

``` ruby
Statuses = Types::Strict::String.enum('draft', 'published', 'archived')
Statuses[1] # => "published"
Statuses['published'] # => "published"
```

Another problem is, lack of validation of integer values. So, you can create enum which maps Stings to Arrays for example.
