### PR TITLE
Evaluate proc values when resolving values in StrictWithDefaults constructor

### DIFF
--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -103,7 +103,7 @@ module Dry
 
         def resolve_missing_value(result, key, type)
           if type.default?
-            result[key] = type.value
+            result[key] = type.evaluate
           else
             super
           end

--- a/spec/dry/types/hash/strict_with_defaults_spec.rb
+++ b/spec/dry/types/hash/strict_with_defaults_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Dry::Types::Hash, ':strict_with_defaults constructor' do
+  subject(:hash) do
+    Dry::Types['hash'].strict_with_defaults(
+      name: 'string',
+      email: email,
+      password: password,
+      created_at: created_at
+    )
+  end
+
+  let(:email) { Dry::Types['optional.strict.string'] }
+  let(:password) { Dry::Types['strict.string'].default('changeme') }
+  let(:created_at) { Dry::Types['strict.time'].default { Time.now } }
+
+  describe '#[]' do
+    it 'fills in default values' do
+      result = hash[name: 'Jane', email: 'foo@bar.com']
+
+      expect(result).to include(
+        name: 'Jane', email: 'foo@bar.com', password: 'changeme'
+      )
+
+      expect(result[:created_at]).to be_instance_of(Time)
+    end
+  end
+end


### PR DESCRIPTION
Before fix:

```ruby
created_at = created_at: Dry::Types['strict.time'].default { Time.now }
hash = Dry::Types['hash'].strict_with_defaults(created_at: created_at)
hash.call.created_at.class # => Proc
```

After:

```ruby
hash.call.created_at.class # => Time
```