### PR TITLE
YARD documentation for Dry::Types

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,5 @@
+--title 'dry-types'
+--markup markdown
+--readme README.md
+--private
+lib/**/*.rb

--- a/Rakefile
+++ b/Rakefile
@@ -13,3 +13,7 @@ task :run_specs do
 end
 
 task default: :run_specs
+
+require 'yard'
+require 'yard/rake/yardoc_task'
+YARD::Rake::YardocTask.new(:doc)

--- a/dry-types.gemspec
+++ b/dry-types.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec", "~> 3.3"
   spec.add_development_dependency 'dry-monads', '~> 0.2'
+  spec.add_development_dependency 'yard', '~> 0.9.5'
 end

--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -29,12 +29,14 @@ module Dry
 
     TYPE_SPEC_REGEX = %r[(.+)<(.+)>].freeze
 
+    # @return [Module]
     def self.module
       namespace = Module.new
       define_constants(namespace, type_keys)
       namespace
     end
 
+    # @deprecated Include {Dry::Types.module} instead
     def self.finalize
       warn 'Dry::Types.finalize and configuring namespace is deprecated. Just'\
        ' do `include Dry::Types.module` in places where you want to have access'\
@@ -109,14 +111,19 @@ module Dry
       end
     end
 
+    # @param [#to_s] klass
+    # @return [String]
     def self.identifier(klass)
       Inflecto.underscore(klass).tr('/', '.')
     end
 
+    # @return [Concurrent::Map]
     def self.type_map
       @type_map ||= Concurrent::Map.new
     end
 
+    # List of type keys defined in {Dry::Types.container}
+    # @return [<String>]
     def self.type_keys
       container._container.keys
     end

--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -23,6 +23,8 @@ module Dry
     extend Dry::Core::Extensions
     include Dry::Core::Constants
 
+    # @!attribute [r] namespace
+    #   @return [Container{String => Definition}]
     setting :namespace, self
 
     TYPE_SPEC_REGEX = %r[(.+)<(.+)>].freeze
@@ -41,19 +43,30 @@ module Dry
       define_constants(config.namespace, type_keys)
     end
 
+    # @return [Container{String => Definition}]
     def self.container
       @container ||= Container.new
     end
 
+    # @param [String] name
+    # @param [Definition] type
+    # @param [#call] block
+    # @return [Container{String => Definition}]
     def self.register(name, type = nil, &block)
       container.register(name, type || block.call)
     end
 
+    # Registers given +klass+ in {#container} using +meth+ constructor
+    # @param [Class] klass
+    # @param [Symbol] meth
+    # @return [Container{String => Definition}]
     def self.register_class(klass, meth = :new)
       type = Definition.new(klass).constructor(klass.method(meth))
       container.register(identifier(klass), type)
     end
 
+    # @param [String] name
+    # @return [Definition]
     def self.[](name)
       type_map.fetch_or_store(name) do
         case name
@@ -78,6 +91,9 @@ module Dry
       end
     end
 
+    # @param [Container{String => Definition}] namespace
+    # @param [<String>] identifiers
+    # @return [<Definition>]
     def self.define_constants(namespace, identifiers)
       names = identifiers.map do |id|
         parts = id.split('.')

--- a/lib/dry/types/array.rb
+++ b/lib/dry/types/array.rb
@@ -3,6 +3,8 @@ require 'dry/types/array/member'
 module Dry
   module Types
     class Array < Definition
+      # @param [Definition] type
+      # @return [Array::Member]
       def member(type)
         member =
           case type

--- a/lib/dry/types/array/member.rb
+++ b/lib/dry/types/array/member.rb
@@ -2,22 +2,36 @@ module Dry
   module Types
     class Array < Definition
       class Member < Array
+        # @return [Definition]
         attr_reader :member
 
+        # @param [Class] primitive
+        # @param [Hash] options
+        # @option options [Definition] :member
         def initialize(primitive, options = {})
           @member = options.fetch(:member)
           super
         end
 
+        # @param [Object] input
+        # @param [Symbol] meth
+        # @return [Array]
         def call(input, meth = :call)
           input.map { |el| member.__send__(meth, el) }
         end
         alias_method :[], :call
 
-        def valid?(type)
-          super && type.all? { |el| member.valid?(el) }
+        # @param [Array, #all?] value
+        # @return [Boolean]
+        def valid?(value)
+          super && value.all? { |el| member.valid?(el) }
         end
 
+        # @param [Array, Object] input
+        # @param [#call] block
+        # @yieldparam [Failure] failure
+        # @yieldreturn [Result]
+        # @return [Result]
         def try(input, &block)
           if input.is_a?(::Array)
             result = call(input, :try)

--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -1,23 +1,35 @@
 module Dry
   module Types
     module Builder
+      include Dry::Core::Constants
+
+      # @return [Constrained]
       def constrained_type
         Constrained
       end
 
+      # @param [Definition] other
+      # @return [Sum, Sum::Constrained]
       def |(other)
         klass = constrained? && other.constrained? ? Sum::Constrained : Sum
         klass.new(self, other)
       end
 
+      # @return [Sum]
       def optional
         Types['strict.nil'] | self
       end
 
+      # @param [Hash] options constraining rule (see {Types.Rule})
+      # @return [Constrained]
       def constrained(options)
         constrained_type.new(self, rule: Types.Rule(options))
       end
 
+      # @param [Object] input
+      # @param [#call] block
+      # @raise [ConstraintError]
+      # @return [Default]
       def default(input = Undefined, &block)
         value = input == Undefined ? block : input
 
@@ -28,14 +40,21 @@ module Dry
         end
       end
 
+      # @param [Array] values
+      # @return [Enum]
       def enum(*values)
         Enum.new(constrained(included_in: values), values: values)
       end
 
+      # @return [Safe]
       def safe
         Safe.new(self)
       end
 
+      # @param [#call] constructor
+      # @param [Hash] options
+      # @param [#call] block
+      # @return [Constructor]
       def constructor(constructor = nil, **options, &block)
         Constructor.new(with(options), fn: constructor || block)
       end

--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -1,10 +1,17 @@
 module Dry
   module Types
     module Coercions
+      include Dry::Core::Constants
+
+      # @param [String] input
+      # @return [String?]
       def to_nil(input)
         input unless empty_str?(input)
       end
 
+      # @param [#to_str, Object] input
+      # @return [Date, Object]
+      # @see Date.parse
       def to_date(input)
         return input unless input.respond_to?(:to_str)
         Date.parse(input)
@@ -12,6 +19,9 @@ module Dry
         input
       end
 
+      # @param [#to_str, Object] input
+      # @return [DateTime, Object]
+      # @see DateTime.parse
       def to_date_time(input)
         return input unless input.respond_to?(:to_str)
         DateTime.parse(input)
@@ -19,6 +29,9 @@ module Dry
         input
       end
 
+      # @param [#to_str, Object] input
+      # @return [Time, Object]
+      # @see Time.parse
       def to_time(input)
         return input unless input.respond_to?(:to_str)
         Time.parse(input)
@@ -28,6 +41,9 @@ module Dry
 
       private
 
+      # Checks whether String is empty
+      # @param [String, Object] value
+      # @return [Boolean]
       def empty_str?(value)
         EMPTY_STRING.eql?(value)
       end

--- a/lib/dry/types/coercions/form.rb
+++ b/lib/dry/types/coercions/form.rb
@@ -11,14 +11,24 @@ module Dry
 
         extend Coercions
 
+        # @param [String, Object] input
+        # @return [Boolean?]
+        # @see TRUE_VALUES
+        # @see FALSE_VALUES
         def self.to_true(input)
           BOOLEAN_MAP.fetch(input.to_s, input)
         end
 
+        # @param [String, Object] input
+        # @return [Boolean?]
+        # @see TRUE_VALUES
+        # @see FALSE_VALUES
         def self.to_false(input)
           BOOLEAN_MAP.fetch(input.to_s, input)
         end
 
+        # @param [#to_int, #to_i, Object] input
+        # @return [Integer?, Object]
         def self.to_int(input)
           if empty_str?(input)
             nil
@@ -29,6 +39,8 @@ module Dry
           input
         end
 
+        # @param [#to_f, Object] input
+        # @return [Float?, Object]
         def self.to_float(input)
           if empty_str?(input)
             nil
@@ -39,6 +51,8 @@ module Dry
           input
         end
 
+        # @param [#to_d, Object] input
+        # @return [BigDecimal?, Object]
         def self.to_decimal(input)
           result = to_float(input)
 
@@ -49,10 +63,14 @@ module Dry
           end
         end
 
+        # @param [Array, '', Object] input
+        # @return [Array, Object]
         def self.to_ary(input)
           empty_str?(input) ? [] : input
         end
 
+        # @param [Hash, '', Object] input
+        # @return [Hash]
         def self.to_hash(input)
           empty_str?(input) ? {} : input
         end

--- a/lib/dry/types/coercions/json.rb
+++ b/lib/dry/types/coercions/json.rb
@@ -9,6 +9,8 @@ module Dry
       module JSON
         extend Coercions
 
+        # @param [#to_d, Object] input
+        # @return [BigDecimal?]
         def self.to_decimal(input)
           input.to_d unless empty_str?(input)
         end

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -9,13 +9,19 @@ module Dry
       include Decorator
       include Builder
 
+      # @return [Dry::Logic::Rule]
       attr_reader :rule
 
+      # @param [Definition] type
+      # @param [Hash] options
       def initialize(type, options)
         super
         @rule = options.fetch(:rule)
       end
 
+      # @param [Object] input
+      # @return [Object]
+      # @raise [ConstraintError]
       def call(input)
         try(input) do |result|
           raise ConstraintError.new(result, input)
@@ -23,6 +29,11 @@ module Dry
       end
       alias_method :[], :call
 
+      # @param [Object] input
+      # @param [#call] block
+      # @yieldparam [Failure] failure
+      # @yieldreturn [Result]
+      # @return [Result]
       def try(input, &block)
         result = rule.(input)
 
@@ -34,20 +45,30 @@ module Dry
         end
       end
 
+      # @param [Object] value
+      # @return [Boolean]
       def valid?(value)
         rule.(value).success? && type.valid?(value)
       end
 
+      # @param [Hash] options
+      #   The options hash provided to {Types.Rule} and combined
+      #   using {&} with previous {#rule}
+      # @return [Constrained]
+      # @see Dry::Logic::Operators#and
       def constrained(options)
         with(rule: rule & Types.Rule(options))
       end
 
+      # @return [true]
       def constrained?
         true
       end
 
       private
 
+      # @param [Object] response
+      # @return [Boolean]
       def decorate?(response)
         super || response.kind_of?(Constructor)
       end

--- a/lib/dry/types/constrained/coercible.rb
+++ b/lib/dry/types/constrained/coercible.rb
@@ -2,6 +2,11 @@ module Dry
   module Types
     class Constrained
       class Coercible < Constrained
+        # @param [Object] input
+        # @param [#call] block
+        # @yieldparam [Failure] failure
+        # @yieldreturn [Result]
+        # @return [Result]
         def try(input, &block)
           result = type.try(input)
 

--- a/lib/dry/types/constraints.rb
+++ b/lib/dry/types/constraints.rb
@@ -4,12 +4,15 @@ require 'dry/logic/rule/predicate'
 
 module Dry
   module Types
+    # @param [Hash] options
+    # @return [Dry::Logic::Rule]
     def self.Rule(options)
       rule_compiler.(
         options.map { |key, val| Logic::Rule::Predicate.new(Logic::Predicates[:"#{key}?"]).curry(val).to_ast }
       ).reduce(:and)
     end
 
+    # @return [Dry::Logic::RuleCompiler]
     def self.rule_compiler
       @rule_compiler ||= Logic::RuleCompiler.new(Logic::Predicates)
     end

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -5,36 +5,54 @@ module Dry
     class Constructor < Definition
       include Dry::Equalizer(:type)
 
+      # @return [#call]
       attr_reader :fn
 
+      # @return [Definition]
       attr_reader :type
 
+      # @param [Builder, Object] input
+      # @param [Hash] options
+      # @param [#call] block
       def self.new(input, options = {}, &block)
         type = input.is_a?(Builder) ? input : Definition.new(input)
         super(type, options, &block)
       end
 
+      # @param [Definition] type
+      # @param [Hash] options
+      # @param [#proc] block
       def initialize(type, options = {}, &block)
         @type = type
         @fn = options.fetch(:fn, block)
         super
       end
 
+      # @return [Class]
       def primitive
         type.primitive
       end
 
+      # @param [Object] input
+      # @return [Object]
       def call(input)
         type[fn[input]]
       end
       alias_method :[], :call
 
+      # @param [Object] input
+      # @param [#call] block
+      # @return [Result]
       def try(input, &block)
         type.try(fn[input], &block)
       rescue TypeError => e
         failure(input, e.message)
       end
 
+      # @param [#call, nil] new_fn
+      # @param [Hash] options
+      # @param [#call] block
+      # @return [Constructor]
       def constructor(new_fn = nil, **options, &block)
         left = new_fn || block
         right = fn
@@ -42,20 +60,30 @@ module Dry
         with(options.merge(fn: -> input { left[right[input]] }))
       end
 
+      # @param [Object] value
+      # @return [Boolean]
       def valid?(value)
         super && type.valid?(value)
       end
 
+      # @return [Class]
       def constrained_type
         Constrained::Coercible
       end
 
       private
 
+      # @param [Symbol] meth
+      # @param [Boolean] include_private
+      # @return [Boolean]
       def respond_to_missing?(meth, include_private = false)
         super || type.respond_to?(meth)
       end
 
+      # Delegates missing methods to {#type}
+      # @param [Symbol] meth
+      # @param [Array] args
+      # @param [#call] block
       def method_missing(meth, *args, &block)
         if type.respond_to?(meth)
           response = type.__send__(meth, *args, &block)

--- a/lib/dry/types/decorator.rb
+++ b/lib/dry/types/decorator.rb
@@ -5,43 +5,62 @@ module Dry
     module Decorator
       include Options
 
+      # @return [Definition]
       attr_reader :type
 
+      # @param [Definition] type
       def initialize(type, *)
         super
         @type = type
       end
 
+      # @return [Constructor]
       def constructor
         type.constructor
       end
 
+      # @param [Object] input
+      # @param [#call] block
+      # @return [Result]
       def try(input, &block)
         type.try(input, &block)
       end
 
+      # @param [Object] value
+      # @return [Boolean]
       def valid?(value)
         type.valid?(value)
       end
 
+      # @return [Boolean]
       def default?
         type.default?
       end
 
+      # @return [Boolean]
       def constrained?
         type.constrained?
       end
 
+      # @param [Symbol] meth
+      # @param [Boolean] include_private
+      # @return [Boolean]
       def respond_to_missing?(meth, include_private = false)
         super || type.respond_to?(meth)
       end
 
       private
 
+      # @param [Object] response
+      # @return [Boolean]
       def decorate?(response)
         response.kind_of?(type.class)
       end
 
+      # Delegates missing methods to {#type}
+      # @param [Symbol] meth
+      # @param [Array] args
+      # @param [#call] block
       def method_missing(meth, *args, &block)
         if type.respond_to?(meth)
           response = type.__send__(meth, *args, &block)

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -10,15 +10,20 @@ module Dry
       class Callable < Default
         include Dry::Equalizer(:type, :options)
 
+        # Evaluates given callable
+        # @return [Object]
         def evaluate
           value.call
         end
       end
 
+      # @return [Object]
       attr_reader :value
 
       alias_method :evaluate, :value
 
+      # @param [Object, #call] value
+      # @return [Default, Dry::Types::Default::Callable]
       def self.[](value)
         if value.respond_to?(:call)
           Callable
@@ -27,23 +32,32 @@ module Dry
         end
       end
 
+      # @param [Definition] type
+      # @param [Object] value
       def initialize(type, value, *)
         super
         @value = value
       end
 
+      # @param [Array] args see {Dry::Types::Builder#constrained}
+      # @return [Default]
       def constrained(*args)
         type.constrained(*args).default(value)
       end
 
+      # @return [true]
       def default?
         true
       end
 
+      # @param [Object] input
+      # @return [Success]
       def try(input)
         success(call(input))
       end
 
+      # @param [Object] input
+      # @return [Object] value passed through {#type} or {#default} value
       def call(input)
         if input.nil?
           evaluate

--- a/lib/dry/types/definition.rb
+++ b/lib/dry/types/definition.rb
@@ -9,10 +9,14 @@ module Dry
       include Options
       include Builder
 
+      # @return [Hash]
       attr_reader :options
 
+      # @return [Class]
       attr_reader :primitive
 
+      # @param [Class] primitive
+      # @return [Definition]
       def self.[](primitive)
         if primitive == ::Array
           Types::Array
@@ -23,29 +27,41 @@ module Dry
         end
       end
 
+      # @param [Class] primitive
+      # @param [Hash] options
       def initialize(primitive, options = {})
         super
         @primitive = primitive
         freeze
       end
 
+      # @return [String]
       def name
         primitive.name
       end
 
+      # @return [false]
       def default?
         false
       end
 
+      # @return [false]
       def constrained?
         false
       end
 
+      # @param [Object] input
+      # @return [Object]
       def call(input)
         input
       end
       alias_method :[], :call
 
+      # @param [Object] input
+      # @param [#call] block
+      # @yieldparam [Failure] failure
+      # @yieldreturn [Result]
+      # @return [Result]
       def try(input, &block)
         if valid?(input)
           success(input)
@@ -55,18 +71,29 @@ module Dry
         end
       end
 
+      # @param (see Dry::Types::Success#initialize)
+      # @return [Success]
       def success(input)
         Result::Success.new(input)
       end
 
+
+      # @param (see Failure#initialize)
+      # @return [Failure]
       def failure(input, error)
         Result::Failure.new(input, error)
       end
 
+      # @param [Object] klass class of the result instance
+      # @param [Array] args arguments for the +klass#initialize+ method
+      # @return [Object] new instance of the given +klass+
       def result(klass, *args)
         klass.new(*args)
       end
 
+      # Checks whether value is of a #primitive class
+      # @param [Object] value
+      # @return [Boolean]
       def primitive?(value)
         value.is_a?(primitive)
       end

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -6,8 +6,15 @@ module Dry
       include Dry::Equalizer(:type, :options, :values)
       include Decorator
 
-      attr_reader :values, :mapping
+      # @return [Array]
+      attr_reader :values
 
+      # @return [Hash]
+      attr_reader :mapping
+
+      # @param [Definition] type
+      # @param [Hash] options
+      # @option options [Array] :values
       def initialize(type, options)
         super
         @values = options.fetch(:values).freeze
@@ -15,6 +22,8 @@ module Dry
         @mapping = values.each_with_object({}) { |v, h| h[values.index(v)] = v }.freeze
       end
 
+      # @param [Object] input
+      # @return [Object]
       def call(input)
         value =
           if values.include?(input)

--- a/lib/dry/types/errors.rb
+++ b/lib/dry/types/errors.rb
@@ -2,9 +2,13 @@ module Dry
   module Types
     extend Dry::Configurable
 
+    # @!attribute [r] namespace
+    #   @return [Container{String => Definition}]
     setting :namespace, self
 
     class SchemaError < TypeError
+      # @param [String] key
+      # @param [Object] value
       def initialize(key, value)
         super("#{value.inspect} (#{value.class}) has invalid type for :#{key}")
       end
@@ -14,20 +18,27 @@ module Dry
     private_constant(:SchemaKeyError)
 
     class MissingKeyError < SchemaKeyError
+      # @param [String] key
       def initialize(key)
         super(":#{key} is missing in Hash input")
       end
     end
 
     class UnknownKeysError < SchemaKeyError
+      # @param [<String, Symbol>] keys
       def initialize(*keys)
         super("unexpected keys #{keys.inspect} in Hash input")
       end
     end
 
-    ConstraintError = Class.new(TypeError) do
-      attr_reader :result, :input
+    class ConstraintError < TypeError
+      # @return [String, #to_s]
+      attr_reader :result
+      # @return [Object]
+      attr_reader :input
 
+      # @param [String, #to_s] result
+      # @param [Object] input
       def initialize(result, input)
         @result = result
         @input = input
@@ -39,6 +50,7 @@ module Dry
         end
       end
 
+      # @return [String]
       def to_s
         "#{input.inspect} violates constraints (#{result} failed)"
       end

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -60,8 +60,13 @@ module Dry
         end
       end
 
-      StrictWithDefaults.include MaybeTypes
-      Schema.include MaybeTypes
+      class StrictWithDefaults < Strict
+        include MaybeTypes
+      end
+
+      class Schema < Hash
+        include MaybeTypes
+      end
     end
 
     # Register non-coercible maybe types

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -9,19 +9,27 @@ module Dry
       include Builder
       include Dry::Monads::Maybe::Mixin
 
+      # @param [Dry::Monads::Maybe, Object] input
+      # @return [Dry::Monads::Maybe]
       def call(input)
         input.is_a?(Dry::Monads::Maybe) ? input : Maybe(type[input])
       end
       alias_method :[], :call
 
+      # @param [Object] input
+      # @return [Result::Success]
       def try(input)
         Result::Success.new(Maybe(type[input]))
       end
 
+      # @return [true]
       def maybe?
         true
       end
 
+      # @param [Object] value
+      # @see Dry::Types::Builder#default
+      # @raise [ArgumentError] if nil provided as default value
       def default(value)
         if value.nil?
           raise ArgumentError, "nil cannot be used as a default of a maybe type"
@@ -32,6 +40,7 @@ module Dry
     end
 
     module Builder
+      # @return [Maybe]
       def maybe
         Maybe.new(Types['strict.nil'] | self)
       end
@@ -39,6 +48,9 @@ module Dry
 
     class Hash
       module MaybeTypes
+        # @param [Hash] result
+        # @param [Symbol] key
+        # @param [Definition] type
         def resolve_missing_value(result, key, type)
           if type.respond_to?(:maybe?) && type.maybe?
             result[key] = type[nil]

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -3,6 +3,11 @@ require 'dry/types/hash/schema'
 module Dry
   module Types
     class Hash < Definition
+      # @param [{Symbol => Definition}] type_map
+      # @param [Class] klass
+      #   {Schema} or one of its subclasses ({Weak}, {Permissive}, {Strict},
+      #   {StrictWithDefaults}, {Symbolized})
+      # @return [Schema]
       def schema(type_map, klass = Schema)
         member_types = type_map.each_with_object({}) { |(name, type), result|
           result[name] =
@@ -15,28 +20,41 @@ module Dry
         klass.new(primitive, options.merge(member_types: member_types))
       end
 
+      # @param [{Symbol => Definition}] type_map
+      # @return [Weak]
       def weak(type_map)
         schema(type_map, Weak)
       end
 
+      # @param [{Symbol => Definition}] type_map
+      # @return [Permissive]
       def permissive(type_map)
         schema(type_map, Permissive)
       end
 
+      # @param [{Symbol => Definition}] type_map
+      # @return [Strict]
       def strict(type_map)
         schema(type_map, Strict)
       end
 
+      # @param [{Symbol => Definition}] type_map
+      # @return [StrictWithDefaults]
       def strict_with_defaults(type_map)
         schema(type_map, StrictWithDefaults)
       end
 
+      # @param [{Symbol => Definition}] type_map
+      # @return [Symbolized]
       def symbolized(type_map)
         schema(type_map, Symbolized)
       end
 
       private
 
+      # @param [Hash] _result
+      # @param [Symbol] _key
+      # @param [Definition] _type
       def resolve_missing_value(_result, _key, _type)
         # noop
       end

--- a/lib/dry/types/options.rb
+++ b/lib/dry/types/options.rb
@@ -1,18 +1,24 @@
 module Dry
   module Types
     module Options
+      # @return [Hash]
       attr_reader :options
 
+      # @see Definition#initialize
       def initialize(*args, **options)
         @__args__ = args
         @options = options
         @meta = options.fetch(:meta, {})
       end
 
+      # @param [Hash] new_options
+      # @return [Definition]
       def with(new_options)
         self.class.new(*@__args__, options.merge(new_options))
       end
 
+      # @param [Hash] data
+      # @return [Hash, Definition]
       def meta(data = nil)
         data ? with(meta: @meta.merge(data)) : @meta
       end

--- a/lib/dry/types/result.rb
+++ b/lib/dry/types/result.rb
@@ -5,17 +5,21 @@ module Dry
     class Result
       include Dry::Equalizer(:input)
 
+      # @return [Object]
       attr_reader :input
 
+      # @param [Object] input
       def initialize(input)
         @input = input
       end
 
       class Success < Result
+        # @return [true]
         def success?
           true
         end
 
+        # @return [false]
         def failure?
           false
         end
@@ -24,21 +28,27 @@ module Dry
       class Failure < Result
         include Dry::Equalizer(:input, :error)
 
+        # @return [#to_s]
         attr_reader :error
 
+        # @param [Object] input
+        # @param [#to_s] error
         def initialize(input, error)
           super(input)
           @error = error
         end
 
+        # @return [String]
         def to_s
           error.to_s
         end
 
+        # @return [false]
         def success?
           false
         end
 
+        # @return [true]
         def failure?
           true
         end

--- a/lib/dry/types/safe.rb
+++ b/lib/dry/types/safe.rb
@@ -7,6 +7,8 @@ module Dry
       include Decorator
       include Builder
 
+      # @param [Object] input
+      # @return [Object]
       def call(input)
         result = try(input)
 
@@ -18,6 +20,11 @@ module Dry
       end
       alias_method :[], :call
 
+      # @param [Object] input
+      # @param [#call] block
+      # @yieldparam [Failure] failure
+      # @yieldreturn [Result]
+      # @return [Result]
       def try(input, &block)
         type.try(input, &block)
       rescue TypeError, ArgumentError => e
@@ -27,6 +34,8 @@ module Dry
 
       private
 
+      # @param [Object, Dry::Types::Constructor] response
+      # @return [Boolean]
       def decorate?(response)
         super || response.kind_of?(Constructor)
       end

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -7,19 +7,26 @@ module Dry
       include Builder
       include Options
 
+      # @return [Definition]
       attr_reader :left
 
+      # @return [Definition]
       attr_reader :right
 
       class Constrained < Sum
+        # @return [Dry::Logic::Rule]
         def rule
           left.rule | right.rule
         end
 
+        # @return [true]
         def constrained?
           true
         end
 
+        # @param [Object] input
+        # @return [Object]
+        # @raise [ConstraintError] if given +input+ not passing {#try}
         def call(input)
           try(input) do |result|
             raise ConstraintError.new(result, input)
@@ -28,28 +35,37 @@ module Dry
         alias_method :[], :call
       end
 
+      # @param [Definition] left
+      # @param [Definition] right
+      # @param [Hash] options
       def initialize(left, right, options = {})
         super
         @left, @right = left, right
         freeze
       end
 
+      # @return [String]
       def name
         [left, right].map(&:name).join(' | ')
       end
 
+      # @return [false]
       def default?
         false
       end
 
+      # @return [false]
       def maybe?
         false
       end
 
+      # @return [false]
       def constrained?
         false
       end
 
+      # @param [Object] input
+      # @return [Object]
       def call(input)
         try(input).input
       end
@@ -69,10 +85,14 @@ module Dry
         end
       end
 
+      # @param [Object] value
+      # @return [Boolean]
       def primitive?(value)
         left.primitive?(value) || right.primitive?(value)
       end
 
+      # @param [Object] value
+      # @return [Boolean]
       def valid?(value)
         left.valid?(value) || right.valid?(value)
       end


### PR DESCRIPTION
I have started working on documenting `Dry::Types` internals. 

I found it much easier to understand the code and how `Dry::Types` are implemented internally. Also, it gives autocompletion for `Dry::Types`-enabled systems in RubyMine and maybe other IDEs.

What do you think about code documentation at all for `dry-` gems family? Would you like to merge this PR with documentation when I document more code?