### PR TITLE
Avoid array splatting in Types::Definition

### DIFF
--- a/lib/dry/types/definition.rb
+++ b/lib/dry/types/definition.rb
@@ -55,12 +55,12 @@ module Dry
         end
       end
 
-      def success(*args)
-        Result::Success.new(*args)
+      def success(input)
+        Result::Success.new(input)
       end
 
-      def failure(*args)
-        Result::Failure.new(*args)
+      def failure(input, error)
+        Result::Failure.new(input, error)
       end
 
       def result(klass, *args)


### PR DESCRIPTION
Array splatting allocates memory unnecessarily because we know the exact
signatures of `Result::Success.new` and `Result::Error.new`.

As a bonus we improved the benchmarks a little bit.

Note the memory and perf **Before** and **After**:
* `271` vs `155` allocations
* `137121` vs `144956` i/s (for `schema#call`)

# Before

## Memory allocations

```
                      filename     type count old_count total_age min_age max_age total_memsize
dry/types/coercions/form.rb:23  T_IMEMO     1         0         0       0       0             0
dry/types/coercions/form.rb:26  T_IMEMO     1         0         0       0       0             0
   dry/types/hash/schema.rb:96  T_IMEMO     1         0         0       0       0             0
  dry/types/hash/schema.rb:138   T_HASH     4         0         0       0       0             0
   dry/types/hash/schema.rb:92   T_HASH     8         0         0       0       0             0
   dry/types/hash/schema.rb:19   T_HASH    14         0         0       0       0             0
   dry/types/hash/schema.rb:60   T_HASH    20         0         0       0       0             0
           dry/types/sum.rb:59   T_DATA    24         0         0       0       0             0
   dry/types/hash/schema.rb:92  T_ARRAY    24         0         0       0       0             0
   dry/types/hash/schema.rb:34  T_ARRAY    28         0         0       0       0             0
    dry/types/definition.rb:59 T_OBJECT    58         0         0       0       0             0
    dry/types/definition.rb:51  T_ARRAY    88         0         0       0       0             0
                         TOTAL            271         0         0       0       0             0
```

## Perf benchmarks

```
Warming up --------------------------------------
         schema#call    12.492k i/100ms
         strict#call     7.871k i/100ms
           weak#call     6.780k i/100ms
     permissive#call    12.473k i/100ms
strict_with_defaults#call
                         8.161k i/100ms
     symbolized#call     6.757k i/100ms
          schema#try     6.942k i/100ms
          strict#try     5.210k i/100ms
            weak#try     6.281k i/100ms
      permissive#try     6.937k i/100ms
strict_with_defaults#try
                         5.207k i/100ms
      symbolized#try     6.316k i/100ms
Calculating -------------------------------------
         schema#call    137.121k (± 0.8%) i/s -    687.060k in   5.010926s
         strict#call     88.035k (± 0.8%) i/s -    440.776k in   5.007122s
           weak#call     72.682k (± 0.7%) i/s -    366.120k in   5.037536s
     permissive#call    137.438k (± 0.6%) i/s -    698.488k in   5.082375s
strict_with_defaults#call
                         86.099k (± 1.4%) i/s -    432.533k in   5.024703s
     symbolized#call     71.729k (± 0.7%) i/s -    364.878k in   5.087149s
          schema#try     73.826k (± 0.7%) i/s -    374.868k in   5.077923s
          strict#try     54.685k (± 1.8%) i/s -    276.130k in   5.051237s
            weak#try     67.673k (± 0.8%) i/s -    339.174k in   5.012231s
      permissive#try     74.056k (± 0.8%) i/s -    374.598k in   5.058589s
strict_with_defaults#try
                         54.825k (± 1.8%) i/s -    275.971k in   5.035506s
      symbolized#try     66.951k (± 0.8%) i/s -    334.748k in   5.000213s

Comparison:
     permissive#call:   137438.1 i/s
         schema#call:   137121.0 i/s - same-ish: difference falls within error
         strict#call:    88035.3 i/s - 1.56x  slower
strict_with_defaults#call:    86098.7 i/s - 1.60x  slower
      permissive#try:    74056.3 i/s - 1.86x  slower
          schema#try:    73826.3 i/s - 1.86x  slower
           weak#call:    72681.6 i/s - 1.89x  slower
     symbolized#call:    71729.0 i/s - 1.92x  slower
            weak#try:    67673.2 i/s - 2.03x  slower
      symbolized#try:    66950.8 i/s - 2.05x  slower
strict_with_defaults#try:    54825.1 i/s - 2.51x  slower
          strict#try:    54685.0 i/s - 2.51x  slower
```

# After

## Memory allocations

```
                      filename     type count old_count total_age min_age max_age total_memsize
dry/types/coercions/form.rb:23  T_IMEMO     1         0         0       0       0             0
dry/types/coercions/form.rb:26  T_IMEMO     1         0         0       0       0             0
   dry/types/hash/schema.rb:96  T_IMEMO     1         0         0       0       0             0
  dry/types/hash/schema.rb:138   T_HASH     4         0         0       0       0             0
   dry/types/hash/schema.rb:92   T_HASH     8         0         0       0       0             0
   dry/types/hash/schema.rb:19   T_HASH    14         0         0       0       0             0
   dry/types/hash/schema.rb:60   T_HASH    20         0         0       0       0             0
           dry/types/sum.rb:59   T_DATA    24         0         0       0       0             0
   dry/types/hash/schema.rb:92  T_ARRAY    24         0         0       0       0             0
    dry/types/definition.rb:59 T_OBJECT    58         0         0       0       0             0
                         TOTAL            155         0         0       0       0             0
```

## Perf benchmarks

```
Warming up --------------------------------------
         schema#call    13.130k i/100ms
         strict#call     8.199k i/100ms
           weak#call     7.362k i/100ms
     permissive#call    12.717k i/100ms
strict_with_defaults#call
                         8.447k i/100ms
     symbolized#call     7.424k i/100ms
          schema#try     7.888k i/100ms
          strict#try     5.761k i/100ms
            weak#try     7.101k i/100ms
      permissive#try     7.946k i/100ms
strict_with_defaults#try
                         5.815k i/100ms
      symbolized#try     6.995k i/100ms
Calculating -------------------------------------
         schema#call    144.956k (± 2.4%) i/s -    735.280k in   5.075495s
         strict#call     88.813k (± 1.7%) i/s -    450.945k in   5.079010s
           weak#call     79.338k (± 0.7%) i/s -    397.548k in   5.011070s
     permissive#call    141.999k (± 2.0%) i/s -    712.152k in   5.017224s
strict_with_defaults#call
                         92.266k (± 0.7%) i/s -    464.585k in   5.035574s
     symbolized#call     80.009k (± 0.7%) i/s -    400.896k in   5.010895s
          schema#try     84.636k (± 0.8%) i/s -    425.952k in   5.033044s
          strict#try     61.516k (± 1.0%) i/s -    311.094k in   5.057585s
            weak#try     76.715k (± 1.0%) i/s -    390.555k in   5.091445s
      permissive#try     83.968k (± 2.1%) i/s -    421.138k in   5.017821s
strict_with_defaults#try
                         60.954k (± 2.3%) i/s -    308.195k in   5.058942s
      symbolized#try     74.966k (± 1.9%) i/s -    377.730k in   5.040688s

Comparison:
         schema#call:   144956.2 i/s
     permissive#call:   141998.8 i/s - same-ish: difference falls within error
strict_with_defaults#call:    92265.7 i/s - 1.57x  slower
         strict#call:    88812.6 i/s - 1.63x  slower
          schema#try:    84636.2 i/s - 1.71x  slower
      permissive#try:    83967.9 i/s - 1.73x  slower
     symbolized#call:    80008.9 i/s - 1.81x  slower
           weak#call:    79338.4 i/s - 1.83x  slower
            weak#try:    76715.3 i/s - 1.89x  slower
      symbolized#try:    74966.4 i/s - 1.93x  slower
          strict#try:    61516.4 i/s - 2.36x  slower
strict_with_defaults#try:    60953.5 i/s - 2.38x  slower
```

# Scripts

## Memory allocations

It's basically `benchmarks/hash_schemas.rb` but run only once wrapped by
[hotch](https://github.com/splattael/hotch)'s memory tracer.

```ruby
$LOAD_PATH.unshift('lib')

require 'bundler/setup'
require 'dry-types'
gem 'hotch', '~> 0.4.0'
require 'hotch/memory'

module SchemaBench
  def self.hash_schema(type)
    Dry::Types['hash'].public_send(type,
      email:   Dry::Types['string'],
      age:     Dry::Types['form.int'],
      admin:   Dry::Types['form.bool'],
      address: Dry::Types['hash'].public_send(type,
        city: Dry::Types['string'],
        street: Dry::Types['string']
      )
    )
  end

  private_class_method(:hash_schema)

  SCHEMAS =
    Dry::Types::Hash
      .public_instance_methods(false)
      .map { |schema_type| [schema_type, hash_schema(schema_type)] }
      .to_h

  INPUT = {
    email: 'jane@doe.org',
    age: '20',
    admin: '1',
    address: { city: 'NYC', street: 'Street 1/2' }
  }
end

GC.disable
Hotch.memory do
  SchemaBench::SCHEMAS.each do |schema_type, schema|
    schema.call(SchemaBench::INPUT)
  end

  SchemaBench::SCHEMAS.each do |schema_type, schema|
    schema.try(SchemaBench::INPUT)
  end
end
```

## Perf benchmarks

It's `benchmarks/hash_schema.rb`

I hope you like it :green_heart:

Feedback is welcome!

Kind regards,
  Peter