### PR TITLE
Returning a new instance of default value for default types

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -20,7 +20,11 @@ module Dry
       # @return [Object]
       attr_reader :value
 
-      alias_method :evaluate, :value
+      def evaluate
+        value.dup
+      rescue
+        value
+      end
 
       # @param [Object, #call] value
       # @return [Default, Dry::Types::Default::Callable]

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -4,12 +4,21 @@ RSpec.describe Dry::Types::Definition, '#default' do
 
     it_behaves_like Dry::Types::Definition
 
-    it 'returns default value when nil is passed' do
-      expect(type[nil]).to eql('foo')
-    end
+    context 'when nil is passed' do
+      it 'returns default value' do
+        expect(type[nil]).to eql('foo')
+      end
 
-    it 'aliases #[] as #call' do
-      expect(type.call(nil)).to eql('foo')
+      it 'returns new instance of default value' do
+        ref_1 = type[nil]
+        ref_2 = type[nil]
+
+        expect(ref_1).not_to equal(ref_2)
+      end
+
+      it 'aliases #[] as #call' do
+        expect(type.call(nil)).to eql('foo')
+      end
     end
 
     it 'returns original value when it is not nil' do


### PR DESCRIPTION
Ran into this bug when working on a project using dry-structs where the same instance of a default value is given to all instances of a class. It only applies when using defaults with a value `String.default('foo')`. 

The current workaround for this is to use the callable version `String.default { 'foo' }`. 
If this is expected behavior, I'd be happy to submit a PR to update the docs to reflect the nuance.

Use case where I ran into the issue:
```
require 'dry-struct'

describe 'Example' do
  module Types
    include ::Dry::Types.module
  end

  class User < ::Dry::Struct
    constructor_type :schema
    attribute :friends, ::Types::Array.default([])
  end

  it 'makes new friends' do
    user = User.new
    expect(user.friends.length).to eq 0 # passes

    user_2 = User.new
    user_2.friends << {}
    expect(user_2.friends.length).to eq 1 # passes

    # Fails here
    expect(user.friends.length).to eq 0
  end
end
```
The above example fails because `user` and `user_2` share the same reference to the default value `[]`
```
Failures:

  1) Example makes new friends
     Failure/Error: expect(user.friends.length).to eq 0

       expected: 0
            got: 1

       (compared using ==)
     # ./spec/example_spec.rb:24:in `block (2 levels) in <top (required)>'
```

It seems like `Dry::Struct` just delegates to the `Default` type for the value so I figured this was the correct spot to account for this change. I also updated the README since `rake spec` is not a defined task.
