### PR TITLE
Add Object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# to-be-released
+
+## Added
+
+* Added `Types::Object` which passes an object of any type (flash-gordon)
+
 # v0.9.3 2016-12-03
 
 ## Fixed

--- a/lib/dry/types/core.rb
+++ b/lib/dry/types/core.rb
@@ -52,6 +52,8 @@ module Dry
     # Register :bool since it's common and not a built-in Ruby type :(
     register("bool", self["true"] | self["false"])
     register("strict.bool", self["strict.true"] | self["strict.false"])
+
+    register("object", Definition[::Object].new(::Object))
   end
 end
 

--- a/spec/dry/types/core_spec.rb
+++ b/spec/dry/types/core_spec.rb
@@ -158,4 +158,24 @@ RSpec.describe Dry::Types::Definition do
       expect(value).to eql('SomeThing')
     end
   end
+
+  describe 'with Object' do
+    let(:object) { Dry::Types['object'] }
+    let(:constrained) { Dry::Types['object'].constrained(type: TrueClass) }
+
+    it_behaves_like Dry::Types::Definition do
+      let(:type) { object }
+    end
+
+    it 'passes through any object' do
+      [Object.new, true, 1, BasicObject.new].each do |o|
+        expect(object[o]).to be o
+      end
+    end
+
+    it 'can be constrained with a specific type' do
+      expect(constrained[true]).to be true
+      expect { constrained[false] }.to raise_error(Dry::Types::ConstraintError)
+    end
+  end
 end


### PR DESCRIPTION
fixes #123

It's a small useful addition allows you to have a placeholder type that can be later constrained with an actual type check. It's also not so uncommon in a dynamically typed language to be in a situation where you just don't know beforehand an object of what type you're going to have. For instance, SQLite despite being a SQL database can return you data of any type it supports in any field of any row, and we have to deal with it.

/cc @solnic 