### PR TITLE
Do not store meta in options

### DIFF
--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -17,7 +17,7 @@ module Dry
             end
         }
 
-        klass.new(primitive, options.merge(member_types: member_types))
+        klass.new(primitive, options.merge(member_types: member_types, meta: meta))
       end
 
       # @param [{Symbol => Definition}] type_map

--- a/lib/dry/types/options.rb
+++ b/lib/dry/types/options.rb
@@ -5,16 +5,16 @@ module Dry
       attr_reader :options
 
       # @see Definition#initialize
-      def initialize(*args, **options)
+      def initialize(*args, meta: EMPTY_HASH, **options)
         @__args__ = args
         @options = options
-        @meta = options.fetch(:meta, {})
+        @meta = meta
       end
 
       # @param [Hash] new_options
       # @return [Type]
       def with(new_options)
-        self.class.new(*@__args__, options.merge(new_options))
+        self.class.new(*@__args__, **options, meta: @meta, **new_options)
       end
 
       # @overload meta

--- a/lib/spec/dry/types.rb
+++ b/lib/spec/dry/types.rb
@@ -42,6 +42,11 @@ RSpec.shared_examples_for 'Dry::Types::Definition#meta' do
       expect(with_meta).to be_instance_of(type.class)
       expect(with_meta.meta).to eql(foo: :bar, baz: '1')
     end
+
+    it "doesn't use meta in equality checks" do
+      expect(type.meta(foo: :bar)).to eql(type)
+      expect(type.meta(foo: :bar).hash).to eql(type.hash)
+    end
   end
 end
 

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dry::Types::Definition, '#default' do
     it_behaves_like Dry::Types::Definition
 
     it 'creates a new type with provided options' do
-      expect(type.options).to eql(meta: { foo: :bar })
+      expect(type.options).to eql({})
       expect(type.meta).to eql(foo: :bar)
     end
 


### PR DESCRIPTION
@solnic I did this because atm `type != type.meta({})` and this is obviously a bug. We need to store an empty hash for meta in options or not to store meta in options at all. I think the latter is better, what do you think about it? 
This allows to simplify code [like this](https://github.com/hanami/model/blob/ade8bf454f08f0bb066dc878aa962f20f11af299/lib/hanami/model/sql/types.rb#L37-L56) at least, while we don't have AST-transformations for types.