### PR TITLE
Add Type#pristine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.10.1 to-be-released
+
+## Added
+
+* `Type#pristine` returns a type without `meta` (flash-gordon)
+
 # v0.10.0 2017-04-26
 
 ## Added

--- a/lib/dry/types/options.rb
+++ b/lib/dry/types/options.rb
@@ -26,6 +26,12 @@ module Dry
       def meta(data = nil)
         data ? with(meta: @meta.merge(data)) : @meta
       end
+
+      # Resets meta
+      # @return [Dry::Types::Type]
+      def pristine
+        with(meta: EMPTY_HASH)
+      end
     end
   end
 end

--- a/lib/spec/dry/types.rb
+++ b/lib/spec/dry/types.rb
@@ -51,6 +51,12 @@ RSpec.shared_examples_for 'Dry::Types::Definition#meta' do
       expect(type).to_not eql(type.meta(i_am: 'different'))
     end
   end
+
+  describe '#pristine' do
+    it 'erases meta' do
+      expect(type.meta(foo: :bar).pristine).to eql(type)
+    end
+  end
 end
 
 RSpec.shared_examples_for Dry::Types::Definition do


### PR DESCRIPTION
This method resets `meta` and allows to compare types ignoring theirs metadata.
This is essentially comparison _by behavior_ rather than comparison _by value_.
