### PR TITLE
make .enum.default raise an error.

### DIFF
--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -36,6 +36,11 @@ module Dry
         type[value || input]
       end
       alias_method :[], :call
+
+      def default(*)
+        raise '.enum(*values).default(value) is not supported. Call '\
+              '.default(value).enum(*values) instead'
+      end
     end
   end
 end

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Dry::Types::Enum do
       expect(with_default[nil]).to eql('draft')
     end
 
-    it 'allows defining a default value for an enum' do
-      with_default = type.default('published')
-
-      expect(with_default[nil]).to eql('published')
+    it "doesn't allows defining a default value for an enum" do
+      expect do
+        type.default('published')
+      end.to raise_error(RuntimeError)
     end
 
     it 'aliases #[] as #call' do


### PR DESCRIPTION
Closes #189.

Wasn't sure whether to raise a custom error type or not - this PR just raises `RuntimeError`. Feel free to tweak the error message.

Note that this is a breaking change.