### PR TITLE
Pass result to schema error for improving error message

### DIFF
--- a/lib/dry/types/errors.rb
+++ b/lib/dry/types/errors.rb
@@ -9,8 +9,9 @@ module Dry
     class SchemaError < TypeError
       # @param [String,Symbol] key
       # @param [Object] value
-      def initialize(key, value)
-        super("#{value.inspect} (#{value.class}) has invalid type for :#{key}")
+      # @param [String, #to_s] result
+      def initialize(key, value, result)
+        super("#{value.inspect} (#{value.class}) has invalid type for :#{key} violates constraints (#{result} failed)")
       end
     end
 

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -88,8 +88,8 @@ module Dry
           resolve(hash) do |type, key, value|
             begin
               type.call(value)
-            rescue ConstraintError
-              raise SchemaError.new(key, value)
+            rescue ConstraintError => e
+              raise SchemaError.new(key, value, e.result)
             end
           end
         end

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Dry::Types::Hash do
   shared_examples 'strict typing behavior' do
     it 'fails if any coercions are unsuccessful' do
       expect { hash.call(name: :Jane, age: 'oops', active: true, phone: []) }
-        .to raise_error(Dry::Types::SchemaError, '"oops" (String) has invalid type for :age')
+        .to raise_error(Dry::Types::SchemaError, '"oops" (String) has invalid type for :age violates constraints (type?(Integer, "oops") failed)')
     end
   end
 
@@ -182,7 +182,7 @@ RSpec.describe Dry::Types::Hash do
 
       it 'fills in default value when value is nil' do
         expect { hash.call(name: :John, active: '1', age: nil, phone: []) }
-          .to raise_error(Dry::Types::SchemaError, 'nil (NilClass) has invalid type for :age')
+          .to raise_error(Dry::Types::SchemaError, 'nil (NilClass) has invalid type for :age violates constraints (type?(Integer, nil) failed)')
       end
     end
   end


### PR DESCRIPTION
These fix https://github.com/dry-rb/dry-struct/issues/16

By passing the `result` message to error we will be able to access it in `dry-struct`