### PR TITLE
Update README to contain correct command to run specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake run_specs` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
The README contains an outdated command to run the specs.

__Wrong__
```
bundle exec rake spec
```

__Correct__
```
bundle exec rake run_specs
```

There are at least these other commands, you can use to run the specs:

* `bundle exec rake` (because `run_specs` is set to be the default task)
* `bundle exec rspec`