### PR TITLE
Do not require value for default type

### DIFF
--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -59,8 +59,8 @@ module Dry
 
       # @param [Object] input
       # @return [Object] value passed through {#type} or {#default} value
-      def call(input)
-        if input.nil?
+      def call(input = Undefined)
+        if input.equal?(Undefined)
           evaluate
         else
           output = type[input]

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -25,15 +25,19 @@ module Dry
 
       # @param [Object] input
       # @return [Object]
-      def call(input)
+      def call(input = Undefined)
         value =
-          if values.include?(input)
+          if input == Undefined
+            type.call
+          elsif values.include?(input)
             input
           elsif mapping.key?(input)
             mapping[input]
+          else
+            input
           end
 
-        type[value || input]
+        type[value]
       end
       alias_method :[], :call
 

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -4,16 +4,20 @@ RSpec.describe Dry::Types::Definition, '#default' do
 
     it_behaves_like Dry::Types::Definition
 
-    it 'returns default value when nil is passed' do
-      expect(type[nil]).to eql('foo')
+    it 'returns default value when no value is passed' do
+      expect(type[]).to eql('foo')
     end
 
     it 'aliases #[] as #call' do
-      expect(type.call(nil)).to eql('foo')
+      expect(type.call).to eql('foo')
     end
 
     it 'returns original value when it is not nil' do
       expect(type['bar']).to eql('bar')
+    end
+
+    it 'returns default value when nil is passed too' do
+      expect(type[nil]).to eql('foo')
     end
   end
 
@@ -24,14 +28,6 @@ RSpec.describe Dry::Types::Definition, '#default' do
       }.to raise_error(
         Dry::Types::ConstraintError, /123/
       )
-    end
-
-    it 'allow to handle the default value using a type' do
-      expect(
-        Dry::Types['strict.string']
-        .constructor(&:to_s)
-        .default { |type| type[123] }[nil]
-      ).to eql('123')
     end
   end
 
@@ -53,21 +49,37 @@ RSpec.describe Dry::Types::Definition, '#default' do
     end
 
     it 'allows setting false' do
-      expect(type.default(false)[nil]).to be(false)
+      expect(type.default(false).call).to be(false)
     end
 
     it 'allows setting true' do
-      expect(type.default(true)[nil]).to be(true)
+      expect(type.default(true).call).to be(true)
     end
   end
 
   context 'with a callable value' do
-    subject(:type) { Dry::Types['time'].default { Time.now } }
+     context 'with 0-arity block' do
+      subject(:type) { Dry::Types['time'].default { Time.now } }
 
-    it_behaves_like Dry::Types::Definition
+      it_behaves_like Dry::Types::Definition
 
-    it 'calls the value' do
-      expect(type[nil]).to be_instance_of(Time)
+      it 'calls the value' do
+        expect(type.call).to be_instance_of(Time)
+      end
+    end
+
+     context 'with 1-arg block' do
+      let(:floor_to_date) { -> t { Time.new(t.year, t.month, t.day) } }
+
+      subject(:type) do
+        Dry::Types['time'].constructor(&floor_to_date).default { |type| type[Time.now] }
+      end
+
+      it_behaves_like Dry::Types::Definition
+
+      it 'can call the next type in the chain' do
+        expect(type.call).to eql(floor_to_date[Time.now])
+      end
     end
   end
 
@@ -90,7 +102,7 @@ RSpec.describe Dry::Types::Definition, '#default' do
     end
 
     it 'calls the value' do
-      expect(type[nil]).to be_instance_of(Time)
+      expect(type.call).to be_instance_of(Time)
     end
   end
 end

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Dry::Types::Enum do
     it 'allows defining an enum from a default-value type' do
       with_default = string.default('draft').enum(*values)
 
-      expect(with_default[nil]).to eql('draft')
+      expect(with_default.call).to eql('draft')
     end
 
     it "doesn't allows defining a default value for an enum" do

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Dry::Types::Sum do
     it 'returns a default value sum type' do
       type = (Dry::Types['nil'] | Dry::Types['string']).default('foo')
 
-      expect(type[nil]).to eql('foo')
+      expect(type.call).to eql('foo')
     end
 
     it 'supports a sum type which includes a constructor type' do
@@ -180,7 +180,7 @@ RSpec.describe Dry::Types::Sum do
     it 'supports a sum type which includes a constrained constructor type' do
       type = (Dry::Types['strict.nil'] | Dry::Types['coercible.int']).default(3)
 
-      expect(type[nil]).to be(3)
+      expect(type[]).to be(3)
       expect(type['3']).to be(3)
       expect(type['7']).to be(7)
     end


### PR DESCRIPTION
This also changes the existing behavior regarding working with `nil`.
From now on when a default type gets `nil` it tries to pass it through
the wrapped type first and see if the output is `nil` or not. If it's
`nil` then the default value will be returned. The reason behind this change
is to make hash schemas simpler in presence of default values. The goal is
to always call a default type in a hash if the key is missing.
The behavior in presence of `nil` was dictated by backward compatibility,
we _may_ change it in future once it causes some unpredicted consequences.