### PR TITLE
Add success and failure method for Sum type

### DIFF
--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -91,6 +91,16 @@ module Dry
         end
       end
 
+      def success(input)
+        if left.valid?(input)
+          left.success(input)
+        elsif right.valid?(input)
+          right.success(input)
+        else
+          raise ArgumentError, "Invalid success value for #{inspect}"
+        end
+      end
+
       # @param [Object] value
       # @return [Boolean]
       def primitive?(value)

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -97,7 +97,15 @@ module Dry
         elsif right.valid?(input)
           right.success(input)
         else
-          raise ArgumentError, "Invalid success value for #{inspect}"
+          raise ArgumentError, "Invalid success value '#{input}' for #{inspect}"
+        end
+      end
+
+      def failure(input)
+        if !left.valid?(input)
+          left.failure(input, left.try(input).error)
+        else
+          right.failure(input, right.try(input).error)
         end
       end
 

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -120,6 +120,20 @@ RSpec.describe Dry::Types::Sum do
     end
   end
 
+  describe '#success' do
+    subject(:type) { Dry::Types['strict.bool'] }
+
+    it 'returns success when value passed' do
+      expect(type.success(true)).to be_success
+    end
+
+    it 'raises ArgumentError when non of the types have a vallid input' do
+      expect{
+        type.success('true')
+      }.to raise_error(ArgumentError, /Invalid success value for/)
+    end
+  end
+
   describe '#default' do
     it 'returns a default value sum type' do
       type = (Dry::Types['nil'] | Dry::Types['string']).default('foo')

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -127,10 +127,18 @@ RSpec.describe Dry::Types::Sum do
       expect(type.success(true)).to be_success
     end
 
-    it 'raises ArgumentError when non of the types have a vallid input' do
+    it 'raises ArgumentError when non of the types have a valid input' do
       expect{
         type.success('true')
-      }.to raise_error(ArgumentError, /Invalid success value for/)
+      }.to raise_error(ArgumentError, /Invalid success value 'true'/)
+    end
+  end
+
+  describe '#failure' do
+    subject(:type) { Dry::Types['int'] | Dry::Types['string'] }
+
+    it 'returns success when value passed' do
+      expect(type.failure(true)).to be_failure
     end
   end
 

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Dry::Types::Sum do
   describe '#failure' do
     subject(:type) { Dry::Types['int'] | Dry::Types['string'] }
 
-    it 'returns success when value passed' do
+    it 'returns failure when invalid value is passed' do
       expect(type.failure(true)).to be_failure
     end
   end


### PR DESCRIPTION
#184 

After checking the code looks like the `Sum` type was missing the `success` method, creating some errors using `dry-struct`.

This PR adds the `success` method.