### PR TITLE
Remove dry-configurable as dependency

### DIFF
--- a/dry-types.gemspec
+++ b/dry-types.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dry-core', '~> 0.2', '>= 0.2.1'
   spec.add_runtime_dependency 'dry-container', '~> 0.3'
   spec.add_runtime_dependency 'dry-equalizer', '~> 0.2'
-  spec.add_runtime_dependency 'dry-configurable', '~> 0.1'
   spec.add_runtime_dependency 'dry-logic', '~> 0.4', '>= 0.4.2'
   spec.add_runtime_dependency 'inflecto', '~> 0.0.0', '>= 0.0.2'
 

--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -9,6 +9,7 @@ require 'dry-container'
 require 'dry-equalizer'
 require 'dry/core/extensions'
 require 'dry/core/constants'
+require 'dry/core/class_attributes'
 
 require 'dry/types/version'
 require 'dry/types/container'
@@ -22,13 +23,15 @@ require 'dry/types/errors'
 
 module Dry
   module Types
-    extend Dry::Configurable
     extend Dry::Core::Extensions
+    extend Dry::Core::ClassAttributes
     include Dry::Core::Constants
 
     # @!attribute [r] namespace
     #   @return [Container{String => Definition}]
-    setting :namespace, self
+    defines :namespace
+
+    namespace self
 
     TYPE_SPEC_REGEX = %r[(.+)<(.+)>].freeze
 
@@ -46,7 +49,7 @@ module Dry
        ' do `include Dry::Types.module` in places where you want to have access'\
        ' to built-in types'
 
-      define_constants(config.namespace, type_keys)
+      define_constants(self.namespace, type_keys)
     end
 
     # @return [Container{String => Definition}]

--- a/lib/dry/types/errors.rb
+++ b/lib/dry/types/errors.rb
@@ -1,10 +1,12 @@
 module Dry
   module Types
-    extend Dry::Configurable
+    extend Dry::Core::ClassAttributes
 
     # @!attribute [r] namespace
     #   @return [Container{String => Definition}]
-    setting :namespace, self
+    defines :namespace
+
+    namespace self
 
     class SchemaError < TypeError
       # @param [String,Symbol] key


### PR DESCRIPTION
As we talk about. 

This removes `dry-configurable` as a dependency.