### PR TITLE
Rework hash schemas

### DIFF
--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -16,7 +16,6 @@ require 'dry/types/inflector'
 require 'dry/types/type'
 require 'dry/types/definition'
 require 'dry/types/constructor'
-require 'dry/types/fn_container'
 require 'dry/types/builder_methods'
 
 require 'dry/types/errors'

--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -31,7 +31,7 @@ module Dry
       # @raise [ConstraintError]
       # @return [Default]
       def default(input = Undefined, &block)
-        value = input == Undefined ? block : input
+        value = input.equal?(Undefined) ? block : input
 
         if value.is_a?(Proc) || valid?(value)
           Default[value].new(self, value)

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -62,6 +62,11 @@ module Dry
         merge_with('hash', constructor, schema).meta(meta)
       end
 
+      def visit_hash_schema(node)
+        schema, meta = node
+        merge_with_schema('hash', schema).meta(meta)
+      end
+
       def visit_json_hash(node)
         schema, meta = node
         merge_with('json.hash', :symbolized, schema).meta(meta)
@@ -88,16 +93,16 @@ module Dry
       end
 
       def merge_with(hash_id, constructor, schema)
-        if constructor == :base
-          registry[hash_id].instantiate(
-            schema.map { |key| visit(key) }.reduce({}, :update)
-          )
-        else
-          registry[hash_id].schema(
-            schema.map { |key| visit(key) }.reduce({}, :update),
-            constructor
-          )
-        end
+        registry[hash_id].schema(
+          schema.map { |key| visit(key) }.reduce({}, :update),
+          constructor
+        )
+      end
+
+      def merge_with_schema(hash_id, schema)
+        registry[hash_id].instantiate(
+          schema.map { |key| visit(key) }.reduce({}, :update)
+        )
       end
     end
   end

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -88,10 +88,16 @@ module Dry
       end
 
       def merge_with(hash_id, constructor, schema)
-        registry[hash_id].instantiate(
-          constructor,
-          schema.map { |key| visit(key) }.reduce({}, :update)
-        )
+        if constructor == :base
+          registry[hash_id].instantiate(
+            schema.map { |key| visit(key) }.reduce({}, :update)
+          )
+        else
+          registry[hash_id].schema(
+            schema.map { |key| visit(key) }.reduce({}, :update),
+            constructor
+          )
+        end
       end
     end
   end

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -88,16 +88,10 @@ module Dry
       end
 
       def merge_with(hash_id, constructor, schema)
-        if constructor.to_s.end_with?('transformed')
-          registry[hash_id].schema_transformed(
-            constructor.to_s.sub('_transformed', '').to_sym,
-            schema.map { |key| visit(key) }.reduce({}, :update)
-          )
-        else
-          registry[hash_id].__send__(
-            constructor, schema.map { |key| visit(key) }.reduce({}, :update)
-          )
-        end
+        registry[hash_id].instantiate(
+          constructor,
+          schema.map { |key| visit(key) }.reduce({}, :update)
+        )
       end
     end
   end

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -88,9 +88,16 @@ module Dry
       end
 
       def merge_with(hash_id, constructor, schema)
-        registry[hash_id].__send__(
-          constructor, schema.map { |key| visit(key) }.reduce({}, :update)
-        )
+        if constructor.to_s.end_with?('transformed')
+          registry[hash_id].schema_transformed(
+            constructor.to_s.sub('_transformed', '').to_sym,
+            schema.map { |key| visit(key) }.reduce({}, :update)
+          )
+        else
+          registry[hash_id].__send__(
+            constructor, schema.map { |key| visit(key) }.reduce({}, :update)
+          )
+        end
       end
     end
   end

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -1,4 +1,5 @@
 require 'dry/types/decorator'
+require 'dry/types/fn_container'
 
 module Dry
   module Types

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -43,6 +43,10 @@ module Dry
         type.name
       end
 
+      def default?
+        type.default?
+      end
+
       # @param [Object] input
       # @return [Object]
       def call(input)

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -59,8 +59,8 @@ module Dry
 
       # @param [Object] input
       # @return [Object] value passed through {#type} or {#default} value
-      def call(input)
-        if input.nil?
+      def call(input = Undefined)
+        if input.equal?(Undefined)
           evaluate
         else
           output = type[input]

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -25,15 +25,19 @@ module Dry
 
       # @param [Object] input
       # @return [Object]
-      def call(input)
+      def call(input = Undefined)
         value =
-          if values.include?(input)
+          if input == Undefined
+            type.call
+          elsif values.include?(input)
             input
           elsif mapping.key?(input)
             mapping[input]
+          else
+            input
           end
 
-        type[value || input]
+        type[value]
       end
       alias_method :[], :call
 

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -27,7 +27,7 @@ module Dry
       # @return [Object]
       def call(input = Undefined)
         value =
-          if input == Undefined
+          if input.equal?(Undefined)
             type.call
           elsif values.include?(input)
             input

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -58,12 +58,11 @@ module Dry
         schema(type_map, :symbolized)
       end
 
-      def instantiate(constructor, member_types)
+      def instantiate(member_types)
         SCHEMA_BUILDER.instantiate(
           primitive,
           **options,
-          member_types: member_types,
-          hash_type: constructor
+          member_types: member_types
         )
       end
     end

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -21,8 +21,10 @@ module Dry
           primitive,
           **options,
           member_types: member_types,
-          meta: meta,
-          extra_keys: klass.extra_keys
+          meta: {
+            **meta,
+            extra_keys: klass.extra_keys
+          }
         )
       end
 

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -1,4 +1,3 @@
-require 'dry/types/hash/schema'
 require 'dry/types/hash/schema_builder'
 
 module Dry
@@ -59,7 +58,7 @@ module Dry
         schema(type_map, :symbolized)
       end
 
-      def schema_transformed(constructor, member_types)
+      def instantiate(constructor, member_types)
         SCHEMA_BUILDER.instantiate(
           primitive,
           **options,

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -8,7 +8,7 @@ module Dry
       #   {Schema} or one of its subclasses ({Weak}, {Permissive}, {Strict},
       #   {StrictWithDefaults}, {Symbolized})
       # @return [Schema]
-      def schema(type_map, klass = Legacy)
+      def schema(type_map, klass = LegacySchema)
         member_types = type_map.each_with_object({}) { |(name, type), result|
           result[name] =
             case type

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -3,12 +3,10 @@ require 'dry/types/hash/schema_builder'
 module Dry
   module Types
     class Hash < Definition
-      SCHEMA_BUILDER = SchemaBuilder.new
+      SCHEMA_BUILDER = SchemaBuilder.new.freeze
 
       # @param [{Symbol => Definition}] type_map
-      # @param [Class] klass
-      #   {Schema} or one of its subclasses ({Weak}, {Permissive}, {Strict},
-      #   {StrictWithDefaults}, {Symbolized})
+      # @param [Symbol] constructor
       # @return [Schema]
       def schema(type_map, constructor = :schema)
         member_types = type_map.each_with_object({}) { |(name, type), result|
@@ -29,35 +27,39 @@ module Dry
       end
 
       # @param [{Symbol => Definition}] type_map
-      # @return [Weak]
+      # @return [Schema]
       def weak(type_map)
         schema(type_map, :weak)
       end
 
       # @param [{Symbol => Definition}] type_map
-      # @return [Permissive]
+      # @return [Schema]
       def permissive(type_map)
         schema(type_map, :permissive)
       end
 
       # @param [{Symbol => Definition}] type_map
-      # @return [Strict]
+      # @return [Schema]
       def strict(type_map)
         schema(type_map, :strict)
       end
 
       # @param [{Symbol => Definition}] type_map
-      # @return [StrictWithDefaults]
+      # @return [Schema]
       def strict_with_defaults(type_map)
         schema(type_map, :strict_with_defaults)
       end
 
       # @param [{Symbol => Definition}] type_map
-      # @return [Symbolized]
+      # @return [Schema]
       def symbolized(type_map)
         schema(type_map, :symbolized)
       end
 
+      # Build a schema from an AST
+      # @api private
+      # @param [{Symbol => Definition}] type_map
+      # @return [Schema]
       def instantiate(member_types)
         SCHEMA_BUILDER.instantiate(primitive, **options, member_types: member_types)
       end

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -59,11 +59,7 @@ module Dry
       end
 
       def instantiate(member_types)
-        SCHEMA_BUILDER.instantiate(
-          primitive,
-          **options,
-          member_types: member_types
-        )
+        SCHEMA_BUILDER.instantiate(primitive, **options, member_types: member_types)
       end
     end
   end

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -1,22 +1,14 @@
-require 'dry/core/class_attributes'
+require 'dry/types/hash/schema'
 
 module Dry
   module Types
     class Hash < Definition
-      extend Dry::Core::ClassAttributes
-
-      defines :hash_type
-
-      defines :extra_keys, type: %i(ignore raise).method(:include?).to_proc
-
-      extra_keys :ignore
-
       # @param [{Symbol => Definition}] type_map
       # @param [Class] klass
       #   {Schema} or one of its subclasses ({Weak}, {Permissive}, {Strict},
       #   {StrictWithDefaults}, {Symbolized})
       # @return [Schema]
-      def schema(type_map, klass = Schema)
+      def schema(type_map, klass = Legacy)
         member_types = type_map.each_with_object({}) { |(name, type), result|
           result[name] =
             case type
@@ -63,23 +55,6 @@ module Dry
       def symbolized(type_map)
         schema(type_map, Symbolized)
       end
-
-      private
-
-      def extra_keys(hash)
-        case options[:extra_keys]
-        when :ignore
-          EMPTY_ARRAY
-        when :raise
-          hash.keys - member_types.keys
-        end
-      end
-
-      def hash_type
-        self.class.hash_type
-      end
     end
   end
 end
-
-require 'dry/types/hash/schema'

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -3,6 +3,16 @@ require 'dry/types/hash/schema'
 module Dry
   module Types
     class Hash < Definition
+      SCHEMAS = {
+        schema: LegacySchema,
+        weak: Weak,
+        permissive: Permissive,
+        strict: Strict,
+        strict_with_defaults: StrictWithDefaults,
+        symbolized: Symbolized
+      }.freeze
+      private_constant(:SCHEMAS)
+
       # @param [{Symbol => Definition}] type_map
       # @param [Class] klass
       #   {Schema} or one of its subclasses ({Weak}, {Permissive}, {Strict},
@@ -17,15 +27,7 @@ module Dry
             end
         }
 
-        klass.new(
-          primitive,
-          **options,
-          member_types: member_types,
-          meta: {
-            **meta,
-            extra_keys: klass.extra_keys
-          }
-        )
+        klass.build(primitive, **options, member_types: member_types, meta: meta)
       end
 
       # @param [{Symbol => Definition}] type_map
@@ -56,6 +58,11 @@ module Dry
       # @return [Symbolized]
       def symbolized(type_map)
         schema(type_map, Symbolized)
+      end
+
+      def schema_transformed(constructor, member_types)
+        klass = SCHEMAS.fetch(constructor)
+        klass.new(primitive, **options, member_types: member_types, meta: meta)
       end
     end
   end

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -66,9 +66,8 @@ module Dry
 
         def to_ast(meta: true)
           [
-            :hash,
+            :hash_schema,
             [
-              :base,
               member_types.map { |name, member| [:member, [name, member.to_ast(meta: meta)]] },
               meta ? self.meta : EMPTY_HASH
             ]

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -87,6 +87,10 @@ module Dry
           meta[:symbolized]
         end
 
+        def permissive?
+          meta[:permissive]
+        end
+
         private
 
         def resolve(hash)
@@ -139,10 +143,9 @@ module Dry
         end
 
         def extra_keys(hash)
-          case meta[:extra_keys]
-          when :ignore
+          if permissive?
             EMPTY_ARRAY
-          when :raise
+          else
             hash.keys - member_types.keys
           end
         end

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -136,7 +136,7 @@ module Dry
         end
 
         def extra_keys(hash)
-          case options[:extra_keys]
+          case meta[:extra_keys]
           when :ignore
             EMPTY_ARRAY
           when :raise

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -106,7 +106,7 @@ module Dry
           member_types.each do |k, type|
             key = key(hash, k)
 
-            unless key.equal?(Undefined)
+            if !key.equal?(Undefined) || type.default?
               result[k] = yield(type, k, hash.fetch(key, Undefined))
             end
           end
@@ -185,7 +185,7 @@ module Dry
         private
 
         def key(hash, key)
-          if hash.key?(key) || member_types[key].default?
+          if hash.key?(key)
             key
           else
             Undefined
@@ -282,7 +282,7 @@ module Dry
         private
 
         def key(hash, key)
-          if hash.key?(key) || member_types[key].default?
+          if hash.key?(key)
             key
           else
             Undefined
@@ -303,8 +303,6 @@ module Dry
             key
           elsif hash.key?(string_key = key.to_s)
             string_key
-          elsif member_types[key].default?
-            key
           else
             Undefined
           end

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -68,7 +68,7 @@ module Dry
           [
             :hash,
             [
-              hash_type,
+              :base,
               member_types.map { |name, member| [:member, [name, member.to_ast(meta: meta)]] },
               meta ? self.meta : EMPTY_HASH
             ]
@@ -82,6 +82,10 @@ module Dry
           result.success?
         end
         alias_method :===, :valid?
+
+        def symbolized?
+          meta[:symbolized]
+        end
 
         private
 
@@ -107,6 +111,8 @@ module Dry
         def key(hash, key)
           if hash.key?(key)
             key
+          elsif symbolized? && hash.key?(string_key = key.to_s)
+            string_key
           else
             Undefined
           end
@@ -138,33 +144,6 @@ module Dry
             EMPTY_ARRAY
           when :raise
             hash.keys - member_types.keys
-          end
-        end
-
-        def hash_type
-          self.options[:hash_type]
-        end
-      end
-
-      class LegacySchema < Schema
-        private
-
-        def hash_type
-          :"#{ super }_transformed"
-        end
-      end
-
-      # {Symbolized} hash will turn string key names into symbols.
-      class Symbolized < LegacyBase
-        private
-
-        def key(hash, key)
-          if hash.key?(key)
-            key
-          elsif hash.key?(string_key = key.to_s)
-            string_key
-          else
-            Undefined
           end
         end
       end

--- a/lib/dry/types/hash/schema_builder.rb
+++ b/lib/dry/types/hash/schema_builder.rb
@@ -1,3 +1,5 @@
+require 'dry/types/hash/schema'
+
 module Dry
   module Types
     class Hash < Definition
@@ -21,25 +23,16 @@ module Dry
           instantiate(primitive, **options, member_types: member_types)
         end
 
-        def instantiate(primitive, options)
-          constructor = options.fetch(:hash_type)
+        def instantiate(primitive, hash_type:, meta: EMPTY_HASH, **options)
           meta = {
-            **options.fetch(:meta, EMPTY_HASH),
-            extra_keys: extra_keys(constructor)
+            extra_keys: extra_keys(hash_type), **meta
           }
+          meta[:symbolized] = true if hash_type == :symbolized
 
-          schema_class(constructor).new(primitive, **options, meta: meta)
+          Schema.new(primitive, **options, meta: meta)
         end
 
         private
-
-        def schema_class(constructor)
-          if constructor == :symbolized
-            Symbolized
-          else
-            LegacySchema
-          end
-        end
 
         def omittable?(constructor)
           @omittable_keys.include?(constructor)

--- a/lib/dry/types/hash/schema_builder.rb
+++ b/lib/dry/types/hash/schema_builder.rb
@@ -13,20 +13,19 @@ module Dry
         end
 
         def call(primitive, options)
-          constructor = options.fetch(:hash_type)
+          hash_type = options.fetch(:hash_type)
           member_types = {}
 
           options.fetch(:member_types).each do |k, t|
-            member_types[k] = build_type(constructor, t)
+            member_types[k] = build_type(hash_type, t)
           end
 
           instantiate(primitive, **options, member_types: member_types)
         end
 
         def instantiate(primitive, hash_type: :base, meta: EMPTY_HASH, **options)
-          meta = {
-            extra_keys: extra_keys(hash_type), **meta
-          }
+          meta = meta.dup
+          meta[:permissive] = true if permissive?(hash_type)
           meta[:symbolized] = true if hash_type == :symbolized
 
           Schema.new(primitive, **options, meta: meta)
@@ -38,8 +37,8 @@ module Dry
           @omittable_keys.include?(constructor)
         end
 
-        def extra_keys(hash_type)
-          @permissive.include?(hash_type) ? :ignore : :raise
+        def permissive?(constructor)
+          @permissive.include?(constructor)
         end
 
         def build_type(constructor, type)

--- a/lib/dry/types/hash/schema_builder.rb
+++ b/lib/dry/types/hash/schema_builder.rb
@@ -1,0 +1,80 @@
+module Dry
+  module Types
+    class Hash < Definition
+      class SchemaBuilder
+        def initialize
+          @nil_to_undefined = -> v { v.nil? ? Undefined : v }
+          @omittable_keys = %i(schema weak symbolized).freeze
+          @permissive = %i(schema permissive weak symbolized).freeze
+
+          freeze
+        end
+
+        def call(primitive, options)
+          constructor = options.fetch(:hash_type)
+          member_types = {}
+
+          options.fetch(:member_types).each do |k, t|
+            member_types[k] = build_type(constructor, t)
+          end
+
+          instantiate(primitive, **options, member_types: member_types)
+        end
+
+        def instantiate(primitive, options)
+          constructor = options.fetch(:hash_type)
+          meta = {
+            **options.fetch(:meta, EMPTY_HASH),
+            extra_keys: extra_keys(constructor)
+          }
+
+          schema_class(constructor).new(primitive, **options, meta: meta)
+        end
+
+        private
+
+        def schema_class(constructor)
+          if constructor == :symbolized
+            Symbolized
+          else
+            LegacySchema
+          end
+        end
+
+        def omittable?(constructor)
+          @omittable_keys.include?(constructor)
+        end
+
+        def extra_keys(hash_type)
+          @permissive.include?(hash_type) ? :ignore : :raise
+        end
+
+        def build_type(constructor, type)
+          type = safe(constructor, type)
+          type = default(constructor, type) if type.default?
+          type = type.meta(omittable: true) if omittable?(constructor)
+          type
+        end
+
+        def safe(constructor, type)
+          if constructor == :weak || constructor == :symbolized
+            type.safe
+          else
+            type
+          end
+        end
+
+        def default(constructor, type)
+          case constructor
+          when :strict_with_defaults
+            type
+          when :strict
+            type.type
+          else
+            type.constructor(@nil_to_undefined)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/types/hash/schema_builder.rb
+++ b/lib/dry/types/hash/schema_builder.rb
@@ -1,4 +1,5 @@
 require 'dry/types/hash/schema'
+require 'dry/types/fn_container'
 
 module Dry
   module Types
@@ -25,8 +26,9 @@ module Dry
 
         def instantiate(primitive, hash_type: :base, meta: EMPTY_HASH, **options)
           meta = meta.dup
+
           meta[:permissive] = true if permissive?(hash_type)
-          meta[:symbolized] = true if hash_type == :symbolized
+          meta[:key_transform_fn] = Schema::SYMBOLIZE_KEY if hash_type == :symbolized
 
           Schema.new(primitive, **options, meta: meta)
         end

--- a/lib/dry/types/hash/schema_builder.rb
+++ b/lib/dry/types/hash/schema_builder.rb
@@ -4,15 +4,16 @@ require 'dry/types/fn_container'
 module Dry
   module Types
     class Hash < Definition
+      # A bulder for legacy schemas
+      # @api private
       class SchemaBuilder
-        def initialize
-          @nil_to_undefined = -> v { v.nil? ? Undefined : v }
-          @omittable_keys = %i(schema weak symbolized).freeze
-          @permissive = %i(schema permissive weak symbolized).freeze
+        NIL_TO_UNDEFINED = -> v { v.nil? ? Undefined : v }
+        OMITTABLE_KEYS = %i(schema weak symbolized).freeze
+        PEMISSIVE = %i(schema permissive weak symbolized).freeze
 
-          freeze
-        end
-
+        # @param primitive [Type]
+        # @option options [Hash{Symbol => Definition}] :member_types
+        # @option options [Symbol] :hash_type
         def call(primitive, options)
           hash_type = options.fetch(:hash_type)
           member_types = {}
@@ -36,11 +37,11 @@ module Dry
         private
 
         def omittable?(constructor)
-          @omittable_keys.include?(constructor)
+          OMITTABLE_KEYS.include?(constructor)
         end
 
         def permissive?(constructor)
-          @permissive.include?(constructor)
+          PEMISSIVE.include?(constructor)
         end
 
         def build_type(constructor, type)
@@ -65,7 +66,7 @@ module Dry
           when :strict
             type.type
           else
-            type.constructor(@nil_to_undefined)
+            type.constructor(NIL_TO_UNDEFINED)
           end
         end
       end

--- a/lib/dry/types/hash/schema_builder.rb
+++ b/lib/dry/types/hash/schema_builder.rb
@@ -23,7 +23,7 @@ module Dry
           instantiate(primitive, **options, member_types: member_types)
         end
 
-        def instantiate(primitive, hash_type:, meta: EMPTY_HASH, **options)
+        def instantiate(primitive, hash_type: :base, meta: EMPTY_HASH, **options)
           meta = {
             extra_keys: extra_keys(hash_type), **meta
           }

--- a/lib/dry/types/safe.rb
+++ b/lib/dry/types/safe.rb
@@ -4,7 +4,7 @@ module Dry
   module Types
     class Safe
       include Type
-      include Dry::Equalizer(:type, :options)
+      include Dry::Equalizer(:type, :options, :meta)
       include Decorator
       include Builder
 

--- a/lib/dry/types/safe.rb
+++ b/lib/dry/types/safe.rb
@@ -4,9 +4,10 @@ module Dry
   module Types
     class Safe
       include Type
-      include Dry::Equalizer(:type, :options, :meta)
+      include Dry::Equalizer(:type)
       include Decorator
       include Builder
+      private :options, :meta
 
       # @param [Object] input
       # @return [Object]
@@ -37,7 +38,7 @@ module Dry
       #
       # @see Definition#to_ast
       def to_ast(meta: true)
-        [:safe, [type.to_ast, meta ? self.meta : EMPTY_HASH]]
+        [:safe, [type.to_ast(meta: meta), EMPTY_HASH]]
       end
 
       # @api public

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -56,11 +56,6 @@ module Dry
       end
 
       # @return [false]
-      def maybe?
-        false
-      end
-
-      # @return [false]
       def constrained?
         false
       end
@@ -101,7 +96,7 @@ module Dry
         end
       end
 
-      def failure(input)
+      def failure(input, _error = nil)
         if !left.valid?(input)
           left.failure(input, left.try(input).error)
         else

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -192,12 +192,12 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     )
   end
 
-  it 'builds an schema-less form.hash' do
+  it 'builds a schema-less form.hash' do
     ast = Dry::Types['form.hash'].schema([]).to_ast
 
     type = compiler.(ast)
 
-    expect(type[nil]).to eql({})
+    expect(type[nil]).to eql(nil)
     expect(type[{}]).to eql({})
   end
 

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -174,9 +174,9 @@ RSpec.describe Dry::Types::Compiler, '#call' do
 
   it 'builds a safe form hash' do
     ast = Dry::Types['form.hash'].symbolized(
-        email: Dry::Types['string'],
-        age: Dry::Types['form.int'],
-        admin: Dry::Types['form.bool'],
+      email: Dry::Types['string'],
+      age: Dry::Types['form.int'],
+      admin: Dry::Types['form.bool'],
     ).to_ast
 
     hash = compiler.(ast)

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -4,16 +4,20 @@ RSpec.describe Dry::Types::Definition, '#default' do
 
     it_behaves_like Dry::Types::Definition
 
-    it 'returns default value when nil is passed' do
-      expect(type[nil]).to eql('foo')
+    it 'returns default value when no value is passed' do
+      expect(type[]).to eql('foo')
     end
 
     it 'aliases #[] as #call' do
-      expect(type.call(nil)).to eql('foo')
+      expect(type.call).to eql('foo')
     end
 
     it 'returns original value when it is not nil' do
       expect(type['bar']).to eql('bar')
+    end
+
+    it 'returns default value when nil is passed too' do
+      expect(type[nil]).to eql('foo')
     end
   end
 
@@ -24,14 +28,6 @@ RSpec.describe Dry::Types::Definition, '#default' do
       }.to raise_error(
         Dry::Types::ConstraintError, /123/
       )
-    end
-
-    it 'allow to handle the default value using a type' do
-      expect(
-        Dry::Types['strict.string']
-        .constructor(&:to_s)
-        .default { |type| type[123] }[nil]
-      ).to eql('123')
     end
   end
 
@@ -53,21 +49,37 @@ RSpec.describe Dry::Types::Definition, '#default' do
     end
 
     it 'allows setting false' do
-      expect(type.default(false)[nil]).to be(false)
+      expect(type.default(false).call).to be(false)
     end
 
     it 'allows setting true' do
-      expect(type.default(true)[nil]).to be(true)
+      expect(type.default(true).call).to be(true)
     end
   end
 
   context 'with a callable value' do
-    subject(:type) { Dry::Types['time'].default { Time.now } }
+     context 'with 0-arity block' do
+      subject(:type) { Dry::Types['time'].default { Time.now } }
 
-    it_behaves_like Dry::Types::Definition
+      it_behaves_like Dry::Types::Definition
 
-    it 'calls the value' do
-      expect(type[nil]).to be_instance_of(Time)
+      it 'calls the value' do
+        expect(type.call).to be_instance_of(Time)
+      end
+    end
+
+     context 'with 1-arg block' do
+      let(:floor_to_date) { -> t { Time.new(t.year, t.month, t.day) } }
+
+      subject(:type) do
+        Dry::Types['time'].constructor(&floor_to_date).default { |type| type[Time.now] }
+      end
+
+      it_behaves_like Dry::Types::Definition
+
+      it 'can call the next type in the chain' do
+        expect(type.call).to eql(floor_to_date[Time.now])
+      end
     end
   end
 
@@ -90,7 +102,7 @@ RSpec.describe Dry::Types::Definition, '#default' do
     end
 
     it 'calls the value' do
-      expect(type[nil]).to be_instance_of(Time)
+      expect(type.call).to be_instance_of(Time)
     end
   end
 end

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Dry::Types::Enum do
     it 'allows defining an enum from a default-value type' do
       with_default = string.default('draft').enum(*values)
 
-      expect(with_default[nil]).to eql('draft')
+      expect(with_default.call).to eql('draft')
     end
 
     it "doesn't allows defining a default value for an enum" do

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Dry::Types::Hash do
         }
       end
 
-      it 'fills in default value when value is nil' do
+      it 'raises an error when nil passed to a default' do
         expect { hash.call(name: :John, active: '1', age: nil, phone: []) }
           .to raise_error(Dry::Types::SchemaError, 'nil (NilClass) has invalid type for :age violates constraints (type?(Integer, nil) failed)')
       end

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Dry::Types::Hash do
     it_behaves_like 'Dry::Types::Definition#meta'
 
     it 'preserves metadata' do
-      expect(hash.meta).to eql(my: :metadata)
+      expect(hash.meta[:my]).to eql(:metadata)
     end
 
     it 'has a Hash primitive' do

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Dry::Types::Sum do
     it 'returns a default value sum type' do
       type = (Dry::Types['nil'] | Dry::Types['string']).default('foo')
 
-      expect(type[nil]).to eql('foo')
+      expect(type.call).to eql('foo')
     end
 
     it 'supports a sum type which includes a constructor type' do
@@ -180,7 +180,7 @@ RSpec.describe Dry::Types::Sum do
     it 'supports a sum type which includes a constrained constructor type' do
       type = (Dry::Types['strict.nil'] | Dry::Types['coercible.int']).default(3)
 
-      expect(type[nil]).to be(3)
+      expect(type[]).to be(3)
       expect(type['3']).to be(3)
       expect(type['7']).to be(7)
     end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -82,10 +82,12 @@ RSpec.describe Dry::Types, '#to_ast' do
 
     %i(schema weak permissive strict strict_with_defaults symbolized).each do |schema|
       if %i(strict strict_with_defaults).include?(schema)
-        extra_keys = :raise
+        meta = { extra_keys: :raise }
       else
-        extra_keys = :ignore
+        meta = { extra_keys: :ignore }
       end
+
+      meta[:symbolized] = true if schema == :symbolized
 
       context "#{schema.capitalize}" do
         subject(:type) { Dry::Types['hash'].send(schema, name: Dry::Types['string'], age: Dry::Types['int']) }
@@ -93,12 +95,12 @@ RSpec.describe Dry::Types, '#to_ast' do
 
         specify do
           expect(type.to_ast).
-            to eql([:hash, [:"#{ schema }_transformed", member_types_ast, extra_keys: extra_keys]])
+            to eql([:hash, [:base, member_types_ast, meta]])
         end
 
         specify 'with meta' do
           expect(type_with_meta.to_ast).
-            to eql([:hash, [:"#{ schema }_transformed", member_types_ast, key: :value, extra_keys: extra_keys]])
+            to eql([:hash, [:base, member_types_ast, key: :value, **meta]])
         end
       end
     end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -81,18 +81,24 @@ RSpec.describe Dry::Types, '#to_ast' do
     end
 
     %i(schema weak permissive strict strict_with_defaults symbolized).each do |schema|
+      if %i(strict strict_with_defaults).include?(schema)
+        extra_keys = :raise
+      else
+        extra_keys = :ignore
+      end
+
       context "#{schema.capitalize}" do
         subject(:type) { Dry::Types['hash'].send(schema, name: Dry::Types['string'], age: Dry::Types['int']) }
         let(:member_types_ast)  { type.member_types.map { |name, member| [:member, [name, member.to_ast]] } }
 
         specify do
           expect(type.to_ast).
-            to eql([:hash, [schema, member_types_ast, {}]])
+            to eql([:hash, [schema, member_types_ast, extra_keys: extra_keys]])
         end
 
         specify 'with meta' do
           expect(type_with_meta.to_ast).
-            to eql([:hash, [schema, member_types_ast, key: :value]])
+            to eql([:hash, [schema, member_types_ast, key: :value, extra_keys: extra_keys]])
         end
       end
     end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -91,12 +91,12 @@ RSpec.describe Dry::Types, '#to_ast' do
 
         specify do
           expect(type.to_ast).
-            to eql([:hash, [:base, member_types_ast, meta]])
+            to eql([:hash_schema, [member_types_ast, meta]])
         end
 
         specify 'with meta' do
           expect(type_with_meta.to_ast).
-            to eql([:hash, [:base, member_types_ast, key: :value, **meta]])
+            to eql([:hash_schema, [member_types_ast, key: :value, **meta]])
         end
       end
     end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -81,12 +81,8 @@ RSpec.describe Dry::Types, '#to_ast' do
     end
 
     %i(schema weak permissive strict strict_with_defaults symbolized).each do |schema|
-      if %i(strict strict_with_defaults).include?(schema)
-        meta = { extra_keys: :raise }
-      else
-        meta = { extra_keys: :ignore }
-      end
-
+      meta = {}
+      meta[:permissive] = true if %i(schema weak symbolized permissive).include?(schema)
       meta[:symbolized] = true if schema == :symbolized
 
       context "#{schema.capitalize}" do

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Dry::Types, '#to_ast' do
     %i(schema weak permissive strict strict_with_defaults symbolized).each do |schema|
       meta = {}
       meta[:permissive] = true if %i(schema weak symbolized permissive).include?(schema)
-      meta[:symbolized] = true if schema == :symbolized
+      meta[:key_transform_fn] = Dry::Types::Hash::Schema::SYMBOLIZE_KEY if schema == :symbolized
 
       context "#{schema.capitalize}" do
         subject(:type) { Dry::Types['hash'].send(schema, name: Dry::Types['string'], age: Dry::Types['int']) }

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -93,12 +93,12 @@ RSpec.describe Dry::Types, '#to_ast' do
 
         specify do
           expect(type.to_ast).
-            to eql([:hash, [schema, member_types_ast, extra_keys: extra_keys]])
+            to eql([:hash, [:"#{ schema }_transformed", member_types_ast, extra_keys: extra_keys]])
         end
 
         specify 'with meta' do
           expect(type_with_meta.to_ast).
-            to eql([:hash, [schema, member_types_ast, key: :value, extra_keys: extra_keys]])
+            to eql([:hash, [:"#{ schema }_transformed", member_types_ast, key: :value, extra_keys: extra_keys]])
         end
       end
     end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -154,10 +154,10 @@ RSpec.describe Dry::Types, '#to_ast' do
                      [
                        [:definition, [String, {}]],
                        [:predicate, [:min_size?, [[:num, 5], [:input, Undefined]]]],
-                       {}
+                       key: :value
                      ]
                    ],
-                   key: :value
+                   {}
                  ]
                ])
     end


### PR DESCRIPTION
This branch depends on https://github.com/dry-rb/dry-types/pull/211

This is a promising start, the end goal is discarding hash schemas. I removed most of the code that relies on inheritance, the next step is removing inheritance altogether. I plan to provide backward compatibility for hash schemas, however, the main point is to provide enough flexibility for building custom-behavior schemas _without_ introducing a ton of barely compatible options. At the moment, I think we'll have to separate weak/symbolized schemas from other types.