### PR TITLE
New API for hash schemas

### DIFF
--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -9,17 +9,7 @@ module Dry
       # @param [Symbol] constructor
       # @return [Schema]
       def schema(type_map, constructor = nil)
-        type_fn = meta.fetch(:type_transform_fn, Schema::NO_TRANSFORM)
-        type_transform = Dry::Types::FnContainer[type_fn]
-
-        member_types = type_map.each_with_object({}) { |(name, type), result|
-          t = case type
-              when String, Class then Types[type]
-              else type
-              end
-
-          result[name] = type_transform.(t)
-        }
+        member_types = transform_types(type_map)
 
         if constructor.nil?
           Schema.new(primitive, member_types: member_types, **options, meta: meta)
@@ -85,6 +75,22 @@ module Dry
 
         handle = Dry::Types::FnContainer.register(fn)
         meta(type_transform_fn: handle)
+      end
+
+      private
+
+      def transform_types(type_map)
+        type_fn = meta.fetch(:type_transform_fn, Schema::NO_TRANSFORM)
+        type_transform = Dry::Types::FnContainer[type_fn]
+
+        type_map.each_with_object({}) { |(name, type), result|
+          t = case type
+              when String, Class then Types[type]
+              else type
+              end
+
+          result[name] = type_transform.(t)
+        }
       end
     end
   end

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -99,16 +99,16 @@ module Dry
         end
         alias_method :===, :valid?
 
-        # Whether the schema accepts (i.e. omits) unknown keys
+        # Whether the schema rejects unknown keys
         # @return [Boolean]
-        def permissive?
-          meta.fetch(:permissive, false)
+        def strict?
+          meta.fetch(:strict, false)
         end
 
-        # Make the schema tolerant to unknown keys
+        # Make the schema intolerant to unknown keys
         # @return [Schema]
-        def permissive
-          meta(permissive: true)
+        def strict
+          meta(strict: true)
         end
 
         # Injects a key transformation function
@@ -143,7 +143,7 @@ module Dry
 
             if member_types.key?(k)
               result[k] = yield(member_types[k], k, value)
-            elsif !permissive?
+            elsif strict?
               raise UnknownKeysError.new(*unexpected_keys(hash.keys))
             end
           end

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -99,10 +99,31 @@ module Dry
         end
         alias_method :===, :valid?
 
-        # Whether the schema accepts unknown keys
+        # Whether the schema accepts (i.e. omits) unknown keys
         # @return [Boolean]
         def permissive?
           meta.fetch(:permissive, false)
+        end
+
+        # Make the schema tolerant to unknown keys
+        # @return [Schema]
+        def permissive
+          meta(permissive: true)
+        end
+
+        # Injects a key transformation function
+        # @param [#call,nil] proc
+        # @param [#call,nil] block
+        # @return [Schema]
+        def with_key_transform(proc = nil, &block)
+          fn = proc || block
+
+          if fn.nil?
+            raise ArgumentError, "a block or callable argument is required"
+          end
+
+          handle = Dry::Types::FnContainer.register(fn)
+          meta(key_transform_fn: handle)
         end
 
         private

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -126,6 +126,13 @@ module Dry
           meta(key_transform_fn: handle)
         end
 
+        # @param [{Symbol => Definition}] type_map
+        # @return [Schema]
+        def schema(type_map)
+          member_types = self.member_types.merge(transform_types(type_map))
+          Schema.new(primitive, **options, member_types: member_types, meta: meta)
+        end
+
         private
 
         def resolve(hash)

--- a/lib/dry/types/hash/schema_builder.rb
+++ b/lib/dry/types/hash/schema_builder.rb
@@ -9,7 +9,7 @@ module Dry
       class SchemaBuilder
         NIL_TO_UNDEFINED = -> v { v.nil? ? Undefined : v }
         OMITTABLE_KEYS = %i(schema weak symbolized).freeze
-        PEMISSIVE = %i(schema permissive weak symbolized).freeze
+        STRICT = %i(strict strict_with_defaults).freeze
 
         # @param primitive [Type]
         # @option options [Hash{Symbol => Definition}] :member_types
@@ -28,7 +28,7 @@ module Dry
         def instantiate(primitive, hash_type: :base, meta: EMPTY_HASH, **options)
           meta = meta.dup
 
-          meta[:permissive] = true if permissive?(hash_type)
+          meta[:strict] = true if strict?(hash_type)
           meta[:key_transform_fn] = Schema::SYMBOLIZE_KEY if hash_type == :symbolized
 
           Schema.new(primitive, **options, meta: meta)
@@ -40,8 +40,8 @@ module Dry
           OMITTABLE_KEYS.include?(constructor)
         end
 
-        def permissive?(constructor)
-          PEMISSIVE.include?(constructor)
+        def strict?(constructor)
+          STRICT.include?(constructor)
         end
 
         def build_type(constructor, type)

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -229,5 +229,12 @@ RSpec.describe Dry::Types::Hash do
           to eql(name: 'Jane', age: 21, active: true)
       end
     end
+
+    describe '#schema' do
+      it 'extends existing schema' do
+        extended = subject.schema(city: "coercible.string")
+        expect(extended.(**valid_input, city: :London)).to include(city: 'London')
+      end
+    end
   end
 end

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -172,27 +172,28 @@ RSpec.describe Dry::Types::Hash do
             )
     end
 
-    it 'rejects unexpected keys' do
-      expected_input = { name: :Jane, age: 21, active: true, phone: ['1', '2'] }
-      unexpected_input = { gender: 'F', email: 'Jane@hotmail.biz' }
-
-      expect {
-        hash.call(expected_input.merge(unexpected_input))
-      }.to raise_error(Dry::Types::UnknownKeysError)
-             .with_message('unexpected keys [:gender, :email] in Hash input')
+    it 'ignores unexpected keys' do
+      expect(subject.(**valid_input, not: :expect)).not_to have_key(:not)
     end
 
-    describe '#permissive' do
-      it 'makes a schema permissive' do
-        schema = subject.permissive
-        expect(schema.(**valid_input, not: :expect)).not_to have_key(:not)
+    describe '#strict' do
+      subject { hash.strict }
+
+      it 'makes the schema strict' do
+        expected_input = { name: :Jane, age: 21, active: true, phone: ['1', '2'] }
+        unexpected_input = { gender: 'F', email: 'Jane@hotmail.biz' }
+
+        expect {
+          subject.(expected_input.merge(unexpected_input))
+        }.to raise_error(Dry::Types::UnknownKeysError)
+               .with_message('unexpected keys [:gender, :email] in Hash input')
       end
     end
 
-    describe '#permissive?' do
+    describe '#strict?' do
       example do
-        expect(subject).not_to be_permissive
-        expect(subject.permissive).to be_permissive
+        expect(subject).not_to be_strict
+        expect(subject.strict).to be_strict
       end
     end
 

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Dry::Types::Hash do
-  let(:type) { Dry::Types['hash'] }
+  subject(:type) { Dry::Types['hash'] }
 
   it_behaves_like Dry::Types::Definition
   it_behaves_like 'Dry::Types::Definition#meta'
@@ -8,6 +8,19 @@ RSpec.describe Dry::Types::Hash do
     it 'accepts any hash input' do
       expect(type.({})).to eql({})
       expect(type.(name: 'Jane')).to eql(name: 'Jane')
+    end
+  end
+
+  describe '#with_type_transform' do
+    it 'adds a type transformation for schemas' do
+      optional_keys = type.with_type_transform { |t| t.meta(omittable: true) }
+      schema = optional_keys.schema(name: "strict.string", age: "strict.int")
+      expect(schema.(name: 'Jane')).to eql(name: 'Jane')
+    end
+
+    it 'accepts a proc' do
+      fn = -> t { t.meta(omittable: true) }
+      expect(subject.with_type_transform(fn)). to eql(subject.with_type_transform(&fn))
     end
   end
 

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Dry::Types, '#to_ast' do
 
     %i(schema weak permissive strict strict_with_defaults symbolized).each do |schema|
       meta = {}
-      meta[:permissive] = true if %i(schema weak symbolized permissive).include?(schema)
+      meta[:strict] = true if %i(strict strict_with_defaults).include?(schema)
       meta[:key_transform_fn] = Dry::Types::Hash::Schema::SYMBOLIZE_KEY if schema == :symbolized
 
       context "#{schema.capitalize}" do


### PR DESCRIPTION
This adds the following API for hash schemas:

1. `Schema#with_key_transform`—transforms keys of input hashes, for things like symbolizing etc.
1. `Schema#strict`—makes a schema intolerant to unknown keys.
1. `Hash#with_type_transform`—transforms member types with an arbitrary block. For instance, 
```ruby
optional_keys = Types::Hash.with_type_transform { |t| t.meta(omittable: true) }
schema = optional_keys.schema(name: 'strict.string', age: 'strict.int')
schema.(name: 'Jane') # => { name: 'Jane' }
```

From my perspective, these three methods is more than enough.