### PR TITLE
Filter out undefined values from arrays (fixes #208)

### DIFF
--- a/lib/dry/types/array/member.rb
+++ b/lib/dry/types/array/member.rb
@@ -34,7 +34,7 @@ module Dry
         # @return [Result,Logic::Result]
         def try(input, &block)
           if input.is_a?(::Array)
-            result = call(input, :try)
+            result = call(input, :try).reject { |r| r.input.equal?(Undefined) }
             output = result.map(&:input)
 
             if result.all?(&:success?)

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -43,6 +43,20 @@ RSpec.describe Dry::Types::Array do
           subject(:type) { array }
         end
       end
+
+      context 'undefined' do
+        subject(:array) {
+          Dry::Types['strict.array'].of(
+            Dry::Types['strict.string'].constructor { |value|
+              value == '' ? Dry::Types::Undefined : value
+            }
+          )
+        }
+
+        it 'filters out undefined values' do
+          expect(array[['', 'foo']]).to eql(['foo'])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This allows constructors to return `Undefined`, such values will be filtered out from the output array.