### PR TITLE
yard doc fixes

### DIFF
--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -49,8 +49,6 @@ module Dry
       end
 
       # Check whether a value is in the enum
-      # @param [Object] value
-      # @return [Boolean]
       alias_method :include?, :valid?
 
       # @api public

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -56,7 +56,7 @@ module Dry
 
       # Build a schema from an AST
       # @api private
-      # @param [{Symbol => Definition}] type_map
+      # @param [{Symbol => Definition}] member_types
       # @return [Schema]
       def instantiate(member_types)
         SCHEMA_BUILDER.instantiate(primitive, **options, member_types: member_types)

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -44,7 +44,6 @@ module Dry
         alias_method :[], :call
 
         # @param [Hash] hash
-        # @param [#call,nil] block
         # @yieldparam [Failure] failure
         # @yieldreturn [Result]
         # @return [Logic::Result]
@@ -167,7 +166,7 @@ module Dry
           end
         end
 
-        # @param [Array<Symbol>]
+        # @param keys [Array<Symbol>]
         # @return [Array<Symbol>]
         def unexpected_keys(keys)
           keys.map(&transform_key) - member_types.keys


### PR DESCRIPTION
There were some leftovers. Also:

- yard catches aliasing (as long as the original method is documented)
- yard automatically assigns boolean type as a return for ```?``` methods (see https://github.com/lsegal/yard/issues/1088)
- for aliases it does not detect param and gives a warning as stated below.

https://app.coditsu.io/dry-rb/builds/validations/72d10c0f-9ab3-4e5b-b673-ecf7f7a5dd74/offenses?q[offense_name_cont]=UnknownParameterName