### PR TITLE
implement a Map type

### DIFF
--- a/lib/dry/types/builder_methods.rb
+++ b/lib/dry/types/builder_methods.rb
@@ -83,7 +83,7 @@ module Dry
         Definition.new(klass).constructor(cons || block || klass.method(:new))
       end
 
-      # Build a definiton type
+      # Build a definition type
       #
       # @param [Class] klass
       #
@@ -91,6 +91,19 @@ module Dry
       # @api public
       def Definition(klass)
         Definition.new(klass)
+      end
+
+      # Build a map type
+      #
+      # @example
+      #   Types::IntMap = Types.Map(keys: Types::Integer)
+      #
+      # @param [Hash] options
+      #
+      # @return [Dry::Types::Map]
+      # @api public
+      def Map(**options)
+        Dry::Types::Map.new(**options)
       end
     end
   end

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -98,6 +98,14 @@ module Dry
         Enum.new(visit(type), mapping: mapping, meta: meta)
       end
 
+      def visit_map(node)
+        options, meta = node
+        types = options.reduce({}) do |h,(k,v)|
+                  h[k] = visit(v); h
+                end
+        Map.new(**types, meta: meta)
+      end
+
       def merge_with(hash_id, constructor, schema)
         registry[hash_id].schema(
           schema.map { |key| visit(key) }.reduce({}, :update),

--- a/lib/dry/types/core.rb
+++ b/lib/dry/types/core.rb
@@ -56,6 +56,8 @@ module Dry
     register("bool", self["true"] | self["false"])
     register("strict.bool", self["strict.true"] | self["strict.false"])
 
+    register("map", Map.new)
+
     register("any", Any)
     register("object", self['any'])
   end

--- a/lib/dry/types/definition.rb
+++ b/lib/dry/types/definition.rb
@@ -6,12 +6,9 @@ module Dry
   module Types
     class Definition
       include Type
-      include Dry::Equalizer(:primitive, :options, :meta)
       include Options
       include Builder
-
-      # @return [Hash]
-      attr_reader :options
+      include Dry::Equalizer(:primitive, :options, :meta)
 
       # @return [Class]
       attr_reader :primitive
@@ -84,18 +81,10 @@ module Dry
         Result::Success.new(input)
       end
 
-
       # @param (see Failure#initialize)
       # @return [Result::Failure]
       def failure(input, error)
         Result::Failure.new(input, error)
-      end
-
-      # @param [Object] klass class of the result instance
-      # @param [Array] args arguments for the +klass#initialize+ method
-      # @return [Object] new instance of the given +klass+
-      def result(klass, *args)
-        klass.new(*args)
       end
 
       # Checks whether value is of a #primitive class
@@ -121,3 +110,4 @@ end
 
 require 'dry/types/array'
 require 'dry/types/hash'
+require 'dry/types/map'

--- a/lib/dry/types/errors.rb
+++ b/lib/dry/types/errors.rb
@@ -17,6 +17,8 @@ module Dry
       end
     end
 
+    MapError = Class.new(TypeError)
+
     SchemaKeyError = Class.new(KeyError)
     private_constant(:SchemaKeyError)
 

--- a/lib/dry/types/map.rb
+++ b/lib/dry/types/map.rb
@@ -1,0 +1,102 @@
+module Dry
+  module Types
+    class Map < Definition
+
+      def initialize(key_type: Any, value_type: Any, meta: EMPTY_HASH)
+        super(::Hash, key_type: key_type, value_type: value_type, meta: meta)
+        validate_options!
+      end
+
+      # @return [Type]
+      def key_type
+        options[:key_type]
+      end
+
+      # @return [Type]
+      def value_type
+        options[:value_type]
+      end
+
+      # @return [String]
+      def name
+        "Map"
+      end
+
+      # @param [Hash] hash
+      # @return [Hash]
+      def call(hash)
+        try(hash) do |failure|
+          raise MapError, failure.error.join("\n")
+        end.input
+      end
+      alias_method :[], :call
+
+      # @param [Hash] hash
+      # @return [Boolean]
+      def valid?(hash)
+        coerce(hash).success?
+      end
+      alias_method :===, :valid?
+
+      # @param [Hash] hash
+      # @return [Result]
+      def try(hash)
+        result = coerce(hash)
+        return result if result.success? || !block_given?
+        yield(result)
+      end
+
+      # @param meta [Boolean] Whether to dump the meta to the AST
+      # @return [Array] An AST representation
+      def to_ast(meta: true)
+        recurse = options.each_with_object({}) do |(k,v),h|
+                    h[k] = v.to_ast(meta: meta)
+                  end
+        [:map, [recurse, meta ? self.meta : EMPTY_HASH]]
+      end
+
+      # @param [Hash] new_options
+      # @return [Map]
+      def with(new_options)
+        self.class.new(**options, meta: @meta, **new_options)
+      end
+
+      private
+
+      def coerce(input)
+        return failure(
+          input, "#{input.inspect} must be an instance of #{primitive}"
+        ) unless primitive?(input)
+
+        output, failures = {}, []
+
+        input.each do |k,v|
+          res_k = options[:key_type].try(k)
+          res_v = options[:value_type].try(v)
+          if res_k.failure?
+            failures << "input key #{k.inspect} is invalid: #{res_k.error}"
+          elsif output.key?(res_k.input)
+            failures << "duplicate coerced hash key #{res_k.input.inspect}"
+          elsif res_v.failure?
+            failures << "input value #{v.inspect} for key #{k.inspect} is invalid: #{res_v.error}"
+          else
+            output[res_k.input] = res_v.input
+          end
+        end
+
+        return success(output) if failures.empty?
+
+        failure(input, failures)
+      end
+
+      def validate_options!
+        [:key_type, :value_type].each do |opt|
+          type = options[opt]
+          next if type.is_a?(Type)
+          raise MapError, ":#{opt} must be a #{Type}, got: #{type.inspect}"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/dry/types/options.rb
+++ b/lib/dry/types/options.rb
@@ -6,9 +6,9 @@ module Dry
 
       # @see Definition#initialize
       def initialize(*args, meta: EMPTY_HASH, **options)
-        @__args__ = args
-        @options = options
-        @meta = meta
+        @__args__ = args.freeze
+        @options = options.freeze
+        @meta = meta.freeze
       end
 
       # @param [Hash] new_options

--- a/lib/dry/types/spec/types.rb
+++ b/lib/dry/types/spec/types.rb
@@ -38,6 +38,13 @@ RSpec.shared_examples_for 'Dry::Types::Definition without primitive' do
       expect(type.optional?).to be_boolean
     end
   end
+
+  context '#options' do
+    it 'are immutable' do
+      expect(type.options).to be_a ::Hash
+      expect(type.options).to be_frozen
+    end
+  end
 end
 
 RSpec.shared_examples_for 'Dry::Types::Definition#meta' do
@@ -55,6 +62,16 @@ RSpec.shared_examples_for 'Dry::Types::Definition#meta' do
 
     it 'equalizes on filled meta' do
       expect(type).to_not eql(type.meta(i_am: 'different'))
+    end
+
+    it 'is locally immutable' do
+      expect(type.meta).to be_a ::Hash
+      expect(type.meta).to be_frozen
+      expect(type.meta).not_to have_key :immutable_test
+      derived = type.with(meta: {immutable_test: 1})
+      expect(derived.meta).to be_frozen
+      expect(derived.meta).to eql({immutable_test: 1})
+      expect(type.meta).not_to have_key :immutable_test
     end
   end
 

--- a/spec/dry/types/map_spec.rb
+++ b/spec/dry/types/map_spec.rb
@@ -1,0 +1,207 @@
+RSpec.describe Dry::Types::Map do
+  context 'shared examples' do
+    let(:type) { Dry::Types::Map.new }
+
+    it_behaves_like 'Dry::Types::Definition#meta'
+
+    it_behaves_like Dry::Types::Definition
+  end
+
+  context 'options' do
+    let(:empty_map) { Dry::Types::Map.new }
+    let(:keyed_map) { Dry::Types::Map.new(key_type: Dry::Types['strict.integer']) }
+    let(:value_map) { Dry::Types::Map.new(value_type: Dry::Types['strict.string']) }
+
+    let(:complex_map) do
+      Dry::Types::Map.new(
+        key_type:   Dry::Types['strict.integer'],
+        value_type: Dry::Types['strict.string'],
+        meta:   { a:1, b:2, c:3 }
+      )
+    end
+
+    describe '#key_type' do
+      it 'can be read' do
+        expect(empty_map.key_type).to eql Dry::Types::Any
+        expect(value_map.key_type).to eql Dry::Types::Any
+        expect(keyed_map.key_type).to eql Dry::Types['strict.integer']
+        expect(complex_map.key_type).to eql Dry::Types['strict.integer']
+      end
+
+      it 'must be a Type' do
+        expect {
+          Dry::Types::Map.new(key_type: "seven")
+        }.to raise_error(Dry::Types::MapError, /must be a Dry::Types::Type/)
+      end
+    end
+
+    describe '#value_type' do
+      it 'can be read' do
+        expect(empty_map.value_type).to eql Dry::Types::Any
+        expect(keyed_map.value_type).to eql Dry::Types::Any
+        expect(value_map.value_type).to eql Dry::Types['strict.string']
+        expect(complex_map.value_type).to eql Dry::Types['strict.string']
+      end
+
+      it 'must be a Type' do
+        expect {
+          Dry::Types::Map.new(value_type: "seven")
+        }.to raise_error(Dry::Types::MapError, /must be a Dry::Types::Type/)
+      end
+    end
+
+    describe '#name' do
+      it 'is Map' do
+        expect(empty_map.name).to eql 'Map'
+        expect(keyed_map.name).to eql 'Map'
+        expect(value_map.name).to eql 'Map'
+        expect(complex_map.name).to eql 'Map'
+      end
+    end
+
+    describe '#primitive' do
+      it 'is Hash' do
+        expect(empty_map.primitive).to eql ::Hash
+        expect(keyed_map.primitive).to eql ::Hash
+        expect(value_map.primitive).to eql ::Hash
+        expect(complex_map.primitive).to eql ::Hash
+      end
+    end
+
+    describe '#with' do
+      it "creates a new Map with different options" do
+        expect(empty_map.with(key_type: Dry::Types['strict.integer'])).to eql keyed_map
+        expect(empty_map.with(value_type: Dry::Types['strict.string'])).to eql value_map
+        partial = value_map.with(key_type: Dry::Types['strict.integer'])
+        expect(partial).not_to eql complex_map
+        expect(partial.with(meta: {a:1, b:2, c:3})).to eql complex_map
+      end
+    end
+
+    describe '#to_ast' do
+      let(:any_ast) { Dry::Types::Any.to_ast }
+      it 'decomposes the map into an ast array' do
+        expect(empty_map.to_ast).to eql [:map, [{key_type: any_ast, value_type: any_ast}, {}]]
+        expect(complex_map.to_ast).to eql [:map, [
+          {
+            key_type:
+              [:constrained, [
+                [:definition, [Integer, {}]],
+                [:predicate, [:type?, [[:type, Integer], [:input, Dry::Types::Undefined]]]],
+                {}
+              ]],
+            value_type:
+              [:constrained, [
+                [:definition, [String, {}]],
+                [:predicate, [:type?, [[:type, String], [:input, Dry::Types::Undefined]]]],
+                {}
+              ]]
+          },
+          { a:1, b:2, c:3 }
+        ]]
+      end
+    end
+  end
+
+  context 'with a sample map' do
+    let(:cleaned_string) do
+      Dry::Types['strict.string'].constructor do |x|
+        x.is_a?(String) ? x.gsub(/\s+/, ' ').strip.downcase : x
+      end
+    end
+
+    let(:map) do
+      Dry::Types::Map.new(
+        key_type:   cleaned_string.constrained(format: /\Aopt_/),
+        value_type: Dry::Types['strict.bool']
+      )
+    end
+
+    context 'with a valid input' do
+      let(:input) do
+        { "opt_one" => false, "  opt_two  " => true, "OPT_THrEe" => true }
+      end
+      let(:output) do
+        { "opt_one" => false, "opt_two" => true, "opt_three" => true }
+      end
+
+      describe '#valid?' do
+        it "is true" do
+          expect(map.valid?(input)).to eql true
+        end
+      end
+
+      describe '#try' do
+        it "returns Result::Success" do
+          result = map.try(input)
+          expect(result).to be_a Dry::Types::Result::Success
+          expect(result.input).to eql output
+        end
+
+        it "does not yield" do
+          expect { |b| map.try(input, &b) }.not_to yield_control
+        end
+      end
+
+      describe '#call' do
+        it 'returns the coerced input' do
+          expect(map.call(input)).to eql output
+        end
+      end
+    end
+
+    context 'with an invalid input' do
+      let(:input) { { opt_sym: false, ' opt_foo ' => 'bar', "other" => true } }
+
+      let(:failures) {[
+        "input key :opt_sym is invalid: type?(String, :opt_sym)",
+        "input value \"bar\" for key \" opt_foo \" is invalid: type?(FalseClass, \"bar\")",
+        "input key \"other\" is invalid: format?(/\\Aopt_/, \"other\")"
+      ]}
+
+      describe '#valid?' do
+        it "is false" do
+          expect(map.valid?(input)).to eql false
+        end
+      end
+
+      describe '#try' do
+        it "returns Result::Failure" do
+          result = map.try(input)
+          expect(result).to be_a Dry::Types::Result::Failure
+          expect(result.error).to eql failures
+        end
+
+        it "yields Result::Failure" do
+          expect do |b|
+            map.try(input, &b)
+          end.to yield_with_args(Dry::Types::Result::Failure)
+        end
+      end
+
+      describe '#call' do
+        it "raises MapError" do
+          expect{ map.call(input) }.to raise_error(
+            Dry::Types::MapError, failures.join("\n"))
+        end
+      end
+    end
+  end
+
+  context 'core' do
+    subject { Dry::Types['map'] }
+
+    it 'is registered' do
+      expect(subject).to eql Dry::Types::Map.new
+    end
+
+    it 'is a Dry::Types::Type' do
+      expect(subject).to be_a Dry::Types::Type
+    end
+
+    it 'is a Dry::Types::Definition' do
+      expect(subject).to be_a Dry::Types::Definition
+    end
+  end
+
+end

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Dry::Types do
     end
   end
 
+  describe '.Map' do
+    it 'builds a map type' do
+      expected = Dry::Types::Map.new(key_type: Dry::Types['integer'])
+      expect(mod.Map(key_type: mod::Integer)).to eql(expected)
+    end
+  end
+
   describe '.Constructor' do
     it 'builds a constructor type' do
       to_s = :to_s.to_proc


### PR DESCRIPTION
@flash-gordon 
implement a Map type based on the discussion from https://github.com/dry-rb/dry-types/issues/113

create one like:
```ruby
Dry::Types::Map.new(key_type: Dry::Types['strict.integer'], value_type: Dry::Types['strict.string'])
```
the empty<sup>[1]</sup> map is registered as `Dry::Types['map']` so you could also do:
```ruby
Dry::Types['map'].with(key_type: Dry::Types['strict.integer'], value_type: Dry::Types['strict.string'])
```
I chose to inherit from `Definition` as opposed to `Hash` to  avoid unintended interactions with the `Schema` logic

[1] by empty I mean unconstrained; any key-value pair is valid

_Edited to reflect the options renaming_