### PR TITLE
Fix Default to allow accepting meta attributes

### DIFF
--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -35,7 +35,7 @@ module Dry
 
       # @param [Type] type
       # @param [Object] value
-      def initialize(type, value, *)
+      def initialize(type, value, **options)
         super
         @value = value
       end

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -31,6 +31,28 @@ RSpec.describe Dry::Types::Definition, '#default' do
     end
   end
 
+  context 'with meta attributes' do
+    context 'default called first' do
+      subject(:type) { Dry::Types['hash'].default({}).meta(omittable: true) }
+
+      it_behaves_like 'Dry::Types::Definition without primitive'
+
+      it 'allows nil' do
+        expect(type[]).to eq({})
+      end
+    end
+
+    context 'default called last' do
+      subject(:type) { Dry::Types['hash'].meta(omittable: true).default({}) }
+
+      it_behaves_like 'Dry::Types::Definition without primitive'
+
+      it 'allows nil' do
+        expect(type[]).to eq({})
+      end
+    end
+  end
+
   context 'with an optional type' do
     subject(:type) { Dry::Types['strict.integer'].optional.default(nil) }
 


### PR DESCRIPTION
We had a strange behavior combining `default` and `meta`

```ruby
type = Dry::Types['hash'].default({}).meta(omittable: true)
type[] # => {:meta=>{:omittable=>true}}
```

With these changes works as expected 

```ruby
type = Dry::Types['hash'].default({}).meta(omittable: true)
type[] # => { }
```