### PR TITLE
Ensure that #valid? returns true for Default type when passed Undefined as value.

### DIFF
--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -57,6 +57,11 @@ module Dry
         success(call(input))
       end
 
+      def valid?(value = Undefined)
+        return true if value == Undefined
+        super
+      end
+
       # @param [Object] input
       # @return [Object] value passed through {#type} or {#default} value
       def call(input = Undefined)

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -58,8 +58,7 @@ module Dry
       end
 
       def valid?(value = Undefined)
-        return true if value == Undefined
-        super
+        value.equal?(Undefined) || super
       end
 
       # @param [Object] input

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -134,4 +134,24 @@ RSpec.describe Dry::Types::Definition, '#default' do
 
     expect(type[]).to eql([])
   end
+
+  describe '#valid?' do
+    subject(:type) { Dry::Types['string'].default('foo') }
+
+    it 'returns true if value is valid' do
+      expect(type.valid?('bar')).to eq true
+    end
+
+    it 'returns false if value is not valid' do
+      expect(type.valid?(nil)).to eq false
+    end
+
+    it 'returns true if value is Undefined' do
+      expect(type.valid?(Dry::Core::Constants::Undefined)).to eq true
+    end
+
+    it 'returns true if no value is passed' do
+      expect(type.valid?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
@flash-gordon as we have spoken passing `Dry::Core::Constants::Undefined` as value to `#valid?` returns true