### PR TITLE
do not return default value if nil is passed

### DIFF
--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -67,7 +67,7 @@ module Dry
         if input.equal?(Undefined)
           evaluate
         else
-          type[input]
+          Undefined.default(type[input]) { evaluate }
         end
       end
       alias_method :[], :call

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -67,8 +67,7 @@ module Dry
         if input.equal?(Undefined)
           evaluate
         else
-          output = type[input]
-          output.nil? ? evaluate : output
+          type[input]
         end
       end
       alias_method :[], :call

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Dry::Types::Definition, '#default' do
       expect(type['bar']).to eql('bar')
     end
 
-    it 'does not returns default value when nil is passed too' do
+    it 'does not return default value when nil is passed' do
       expect(type[nil]).to eql(nil)
     end
   end
@@ -147,11 +147,22 @@ RSpec.describe Dry::Types::Definition, '#default' do
     end
 
     it 'returns true if value is Undefined' do
-      expect(type.valid?(Dry::Core::Constants::Undefined)).to eq true
+      expect(type.valid?(Undefined)).to eq true
     end
 
     it 'returns true if no value is passed' do
       expect(type.valid?).to eq true
+    end
+  end
+
+  context 'with a constructor' do
+    describe 'returning Undefined' do
+      let(:non_empty_string) { Dry::Types['string'].constructor { |str| str.empty? ? Undefined : str } }
+      subject(:type) { non_empty_string.default("empty") }
+
+      it 'returns default value on empty input' do
+        expect(type[""]).to eql("empty")
+      end
     end
   end
 end

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Dry::Types::Definition, '#default' do
       expect(type['bar']).to eql('bar')
     end
 
-    it 'returns default value when nil is passed too' do
-      expect(type[nil]).to eql('foo')
+    it 'does not returns default value when nil is passed too' do
+      expect(type[nil]).to eql(nil)
     end
   end
 

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -173,8 +173,7 @@ RSpec.describe Dry::Types::Sum do
 
     it 'supports a sum type which includes a constructor type' do
       type = (Dry::Types['params.nil'] | Dry::Types['params.integer']).default(3)
-
-      expect(type['']).to be(3)
+      expect(type['']).to be(nil)
     end
 
     it 'supports a sum type which includes a constrained constructor type' do


### PR DESCRIPTION
@flash-gordon 

The issue was found in https://github.com/dry-rb/dry-struct/issues/90

Do not return the default value when passing `nil`