### PR TITLE
do not print deprecation warning each time the gem is loaded

### DIFF
--- a/lib/dry/types/compat/form_types.rb
+++ b/lib/dry/types/compat/form_types.rb
@@ -1,7 +1,5 @@
 require 'dry/core/deprecations'
 
-Dry::Core::Deprecations.warn('Form types were renamed to Params', tag: :'dry-types')
-
 module Dry
   module Types
     container.keys.grep(/^params\./).each do |key|

--- a/lib/dry/types/compat/int.rb
+++ b/lib/dry/types/compat/int.rb
@@ -1,7 +1,5 @@
 require 'dry/core/deprecations'
 
-Dry::Core::Deprecations.warn('Int type was renamed to Integer', tag: :'dry-types')
-
 module Dry
   module Types
     register('int', self['integer'])


### PR DESCRIPTION
this resolves issue #264 

I read your Pull Request guidelines, but the kind of test that verifies this change does not belong in a test suite, IMHO, and since @flash-gordon didn't include any tests when he introduced this user-hostile behavior in https://github.com/dry-rb/dry-types/commit/6c1ff65a, I don't see why I should try to write a test when removing it.