### PR TITLE
Return Failure object when using `try` with Types::Hash

### DIFF
--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -60,7 +60,7 @@ module Dry
 
                 member_result
               end
-            rescue ConstraintError, UnknownKeysError, SchemaError => e
+            rescue ConstraintError, UnknownKeysError, SchemaError, MissingKeyError => e
               success = false
               result = e
             end

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -146,6 +146,14 @@ RSpec.describe Dry::Types::Hash do
       end
     end
 
+    it 'returns failure on #try when a member is missing' do
+      input = { active: '0', name: 'John', phone: %w[1 234] }
+
+      result = hash.try(input)
+
+      expect(result).to be_failure
+    end
+
     describe '#valid?' do
       it 'returns boolean' do
         expect(hash.valid?(name: 'John', age: 23, active: 1, phone: 1)).to eql(true)


### PR DESCRIPTION
Fix #270 

@flash-gordon 

We were missing `MissingKeyError ` from the rescue block inside `try` for schema
