### PR TITLE
Add Constructor#{prepend,append}

### DIFF
--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -44,6 +44,7 @@ module Dry
         type.name
       end
 
+      # @return [Boolean]
       def default?
         type.default?
       end
@@ -73,8 +74,9 @@ module Dry
         left = new_fn || block
         right = fn
 
-        with(options.merge(fn: -> input { left[right[input]] }))
+        with(**options, fn: -> input { left[right[input]] })
       end
+      alias_method :append, :constructor
 
       # @param [Object] value
       # @return [Boolean]
@@ -95,6 +97,19 @@ module Dry
         [:constructor, [type.to_ast(meta: meta),
                         register_fn(fn),
                         meta ? self.meta : EMPTY_HASH]]
+      end
+
+      # @api public
+      #
+      # @param [#call, nil] new_fn
+      # @param [Hash] options
+      # @param [#call, nil] block
+      # @return [Constructor]
+      def prepend(new_fn = nil, **options, &block)
+        left = new_fn || block
+        right = fn
+
+        with(**options, fn: -> input { right[left[input]] })
       end
 
       private

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -77,6 +77,7 @@ module Dry
         with(**options, fn: -> input { left[right[input]] })
       end
       alias_method :append, :constructor
+      alias_method :>>, :constructor
 
       # @param [Object] value
       # @return [Boolean]
@@ -111,6 +112,7 @@ module Dry
 
         with(**options, fn: -> input { right[left[input]] })
       end
+      alias_method :<<, :prepend
 
       private
 

--- a/spec/dry/types/constructor_spec.rb
+++ b/spec/dry/types/constructor_spec.rb
@@ -167,4 +167,20 @@ RSpec.describe Dry::Types::Constructor do
       expect(type.method(:append)).to eql(type.method(:constructor))
     end
   end
+
+  describe '#<<' do
+    subject(:type) { Dry::Types['coercible.integer'] }
+
+    it 'is an alias for #prepend' do
+      expect(type.method(:<<)).to eql(type.method(:prepend))
+    end
+  end
+
+  describe '#>>' do
+    subject(:type) { Dry::Types['coercible.integer'] }
+
+    it 'is an alias for #append' do
+      expect(type.method(:>>)).to eql(type.method(:append))
+    end
+  end
 end

--- a/spec/dry/types/constructor_spec.rb
+++ b/spec/dry/types/constructor_spec.rb
@@ -144,4 +144,27 @@ RSpec.describe Dry::Types::Constructor do
       expect(type.try('foo')).to be_failure
     end
   end
+
+  describe '#prepend' do
+    subject(:type) { Dry::Types['coercible.integer'] }
+
+    it 'prepends the constructor' do
+      expect(type.prepend(-> s { s.ord })['foo']).to eql(102)
+    end
+
+    it 'accepts block' do
+      prepended = type.prepend(id: 'named') { |s| s.ord }
+
+      expect(prepended['foo']).to eql(102)
+      expect(prepended.options).to include(id: 'named')
+    end
+  end
+
+  describe '#append' do
+    subject(:type) { Dry::Types['coercible.integer'] }
+
+    it 'is an alias for #constructor' do
+      expect(type.method(:append)).to eql(type.method(:constructor))
+    end
+  end
 end


### PR DESCRIPTION
Consequent calls of `.constructor` lead to right-to-left composition i.e. the block you're passing will be called _after_ the underlying constructor. Sometimes you want to prepend a block, that's what `Constructor#prepend` does. I also added Constructor#append as an alias for `#constructor`.

I believe this addresses #258

@solnic @timriley are you happy with names? E.g. it can be before/after