### PR TITLE
Apply constructor fn before checking validity of input

### DIFF
--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -1,4 +1,3 @@
-require 'dry/types/decorator'
 require 'dry/types/fn_container'
 
 module Dry
@@ -79,9 +78,11 @@ module Dry
       # @param [Object] value
       # @return [Boolean]
       def valid?(value)
-        type.valid?(fn[value])
+        constructed_value = fn[value]
       rescue NoMethodError, TypeError
         false
+      else
+        type.valid?(constructed_value)
       end
       alias_method :===, :valid?
 

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -79,7 +79,9 @@ module Dry
       # @param [Object] value
       # @return [Boolean]
       def valid?(value)
-        type.valid?(value)
+        type.valid?(fn[value])
+      rescue NoMethodError, TypeError
+        false
       end
       alias_method :===, :valid?
 

--- a/spec/dry/types/constrained_spec.rb
+++ b/spec/dry/types/constrained_spec.rb
@@ -72,6 +72,28 @@ RSpec.describe Dry::Types::Constrained do
     it 'fails when coercion fails' do
       expect { type['foo'] }.to raise_error(Dry::Types::ConstraintError, /foo/)
     end
+
+    context 'constructor fn changes validity' do
+      context 'from invalid to valid' do
+        subject(:type) do
+          Dry::Types['strict.integer'].constrained(gt: 1).constructor { |x| x + 1 }
+        end
+
+        it 'passes' do
+          expect(type.valid?(1)).to eql(true)
+        end
+      end
+
+      context 'from valid to invalid' do
+        subject(:type) do
+          Dry::Types['strict.integer'].constrained(gt: 1).constructor { |x| x - 1 }
+        end
+
+        it 'fails' do
+          expect(type.valid?(2)).to eql(false)
+        end
+      end
+    end
   end
 
   context 'with an optional sum type' do

--- a/spec/dry/types/constructor_spec.rb
+++ b/spec/dry/types/constructor_spec.rb
@@ -31,10 +31,34 @@ RSpec.describe Dry::Types::Constructor do
     end
   end
 
-  describe '#===' do
+  describe '#valid?' do
     it 'returns boolean' do
-      expect(type.===('hello')).to eql(true)
-      expect(type.===(nil)).to eql(false)
+      expect(type.valid?('hello')).to eql(true)
+    end
+
+    context 'fn makes invalid input valid' do
+      it 'returns true' do
+        expect(type.valid?(nil)).to eql(true)
+      end
+    end
+
+    context 'fn raises NoMethodError' do
+      let(:type) { Dry::Types::Constructor.new(String, &:strip) }
+
+      it 'returns false' do
+        expect(type.valid?(nil)).to eql(false)
+      end
+    end
+
+    context 'fn raises TypeError' do
+      let(:type) do
+        array = [1, 2, 3]
+        Dry::Types::Constructor.new(String) { |x| array[x + 1].to_s }
+      end
+
+      it 'returns false' do
+        expect(type.valid?('one')).to eql(false)
+      end
     end
 
     context 'in case statement' do

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -198,7 +198,7 @@ RSpec.describe Dry::Types::Sum do
     it 'returns if value is valid' do
       expect(type.valid?('hello')).to eql(true)
       expect(type.valid?(nil)).to eql(true)
-      expect(type.valid?(10)).to eql(false)
+      expect(type.valid?(10)).to eql(true)
     end
   end
 


### PR DESCRIPTION
This PR addresses the following incorrect behavior for `Constructor#valid?`, where a type with a constructor `fn` does not apply it to the value before checking its validity:
```ruby
BMI = Dry::Types['strict.int'].constrained(gteq: 18, lteq: 42).constructor { |x| x.round }

BMI[17.5]
#=> 18

BMI.valid?(17.5)
#=> false
```
After the changes, the call to `#valid?` above will return `true`.

Since it's just a check, a rescue clause was added in order to always return a boolean.