### PR TITLE
Fix descriptions of types registered

### DIFF
--- a/lib/dry/types/core.rb
+++ b/lib/dry/types/core.rb
@@ -2,6 +2,7 @@ require 'dry/types/any'
 
 module Dry
   module Types
+    # Primitives with {Kernel} coercion methods
     COERCIBLE = {
       string: String,
       integer: Integer,
@@ -11,6 +12,7 @@ module Dry
       hash: ::Hash
     }.freeze
 
+    # Primitives that are non-coercible through {Kernel} methods
     NON_COERCIBLE = {
       nil: NilClass,
       symbol: Symbol,
@@ -23,36 +25,38 @@ module Dry
       range: Range
     }.freeze
 
+    # All built-in primitives
     ALL_PRIMITIVES = COERCIBLE.merge(NON_COERCIBLE).freeze
 
+    # All built-in primitives except {NilClass}
     NON_NIL = ALL_PRIMITIVES.reject { |name, _| name == :nil }.freeze
 
-    # Register built-in types that are non-coercible through kernel methods
+    # Register generic types for {ALL_PRIMITIVES}
     ALL_PRIMITIVES.each do |name, primitive|
       register(name.to_s, Definition[primitive].new(primitive))
     end
 
-    # Register strict built-in types that are non-coercible through kernel methods
+    # Register strict types for {ALL_PRIMITIVES}
     ALL_PRIMITIVES.each do |name, primitive|
       register("strict.#{name}", self[name.to_s].constrained(type: primitive))
     end
 
-    # Register built-in primitive types with kernel coercion methods
+    # Register {COERCIBLE} types
     COERCIBLE.each do |name, primitive|
       register("coercible.#{name}", self[name.to_s].constructor(Kernel.method(primitive.name)))
     end
 
-    # Register non-coercible optional types
+    # Register optional strict {NON_NIL} types
     NON_NIL.each_key do |name|
       register("optional.strict.#{name}", self["strict.#{name}"].optional)
     end
 
-    # Register coercible optional types
+    # Register optional {COERCIBLE} types
     COERCIBLE.each_key do |name|
       register("optional.coercible.#{name}", self["coercible.#{name}"].optional)
     end
 
-    # Register :bool since it's common and not a built-in Ruby type :(
+    # Register `:bool` since it's common and not a built-in Ruby type :(
     register("bool", self["true"] | self["false"])
     register("strict.bool", self["strict.true"] | self["strict.false"])
 


### PR DESCRIPTION
Both [`lib/dry/types/core.rb:30`](#diff-eb310b9f51700ccb1cb335c0dad7b7ffL30) and [`lib/dry/types/core.rb:35`](#diff-eb310b9f51700ccb1cb335c0dad7b7ffL35) register all primitives and not only those that are non-coercible through kernel methods.

Also I have described constants and used links to them to simplify descriptions of what has been registered.