### PR TITLE
fix detecting invalid integers

### DIFF
--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -79,7 +79,7 @@ module Dry
       # @return [Boolean]
       def valid?(value)
         constructed_value = fn[value]
-      rescue NoMethodError, TypeError
+      rescue NoMethodError, TypeError, ArgumentError
         false
       else
         type.valid?(constructed_value)

--- a/spec/dry/types/constructor_spec.rb
+++ b/spec/dry/types/constructor_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe Dry::Types::Constructor do
       end
     end
 
+    it 'returns boolean for invalid integer' do
+      type = Dry::Types['coercible.integer']
+
+      expect(type.valid?('hello')).to eql(false)
+    end
+
     context 'fn raises NoMethodError' do
       let(:type) { Dry::Types::Constructor.new(String, &:strip) }
 
@@ -54,6 +60,16 @@ RSpec.describe Dry::Types::Constructor do
       let(:type) do
         array = [1, 2, 3]
         Dry::Types::Constructor.new(String) { |x| array[x + 1].to_s }
+      end
+
+      it 'returns false' do
+        expect(type.valid?('one')).to eql(false)
+      end
+    end
+
+    context 'fn raises ArgumentError' do
+      let(:type) do
+        Dry::Types::Constructor.new(String) { |x| Integer(x) }
       end
 
       it 'returns false' do


### PR DESCRIPTION
`Dry::Types['coercible.integer']` uses `Integer()` as a constructor, which raises `ArgumentError` if it can't coerce the input.

`Dry::Types::Constructor#valid?` only caught `TypeError` and `NoMethodError`, so it would raise for checking the validity of an invalid integer.