### PR TITLE
Add type printer with better type introspection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source 'https://rubygems.org'
 
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
+
 gemspec
+
+gem 'dry-equalizer', github: 'dry-rb/dry-equalizer'
 
 group :test do
   platform :mri do

--- a/bin/console
+++ b/bin/console
@@ -7,10 +7,13 @@ module Types
   include Dry::Types.module
 end
 
+
 begin
   require 'pry-byebug'
-  Pry.start
+  binding.pry
 rescue LoadError
   require 'irb'
-  IRB.start
+  binding.irb
 end
+
+puts

--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -17,6 +17,7 @@ require 'dry/types/type'
 require 'dry/types/definition'
 require 'dry/types/constructor'
 require 'dry/types/builder_methods'
+require 'dry/types/printer'
 
 require 'dry/types/errors'
 
@@ -33,6 +34,8 @@ module Dry
     namespace self
 
     TYPE_SPEC_REGEX = %r[(.+)<(.+)>].freeze
+
+    PRINTER = Printer.new.freeze
 
     # @return [Module]
     def self.module

--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -17,7 +17,6 @@ require 'dry/types/type'
 require 'dry/types/definition'
 require 'dry/types/constructor'
 require 'dry/types/builder_methods'
-require 'dry/types/printer'
 
 require 'dry/types/errors'
 
@@ -34,8 +33,6 @@ module Dry
     namespace self
 
     TYPE_SPEC_REGEX = %r[(.+)<(.+)>].freeze
-
-    PRINTER = Printer.new.freeze
 
     # @return [Module]
     def self.module
@@ -154,3 +151,4 @@ end
 
 require 'dry/types/core' # load built-in types
 require 'dry/types/extensions'
+require 'dry/types/printer'

--- a/lib/dry/types/any.rb
+++ b/lib/dry/types/any.rb
@@ -1,6 +1,10 @@
 module Dry
   module Types
     Any = Class.new(Definition) do
+      def self.name
+        'Any'
+      end
+
       def initialize(**options)
         super(::Object, options)
       end

--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -38,7 +38,7 @@ module Dry
       def default(input = Undefined, &block)
         value = input.equal?(Undefined) ? block : input
 
-        if value.is_a?(Proc) || valid?(value)
+        if value.respond_to?(:call) || valid?(value)
           Default[value].new(self, value)
         else
           raise ConstraintError.new("default value #{value.inspect} violates constraints", value)
@@ -70,6 +70,13 @@ module Dry
       def constructor(constructor = nil, **options, &block)
         constructor_type.new(with(options), fn: constructor || block)
       end
+
+      # @return [String]
+      # @api public
+      def to_s
+        PRINTER.(self)
+      end
+      alias_method :inspect, :to_s
     end
   end
 end

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -6,7 +6,7 @@ module Dry
   module Types
     class Constrained
       include Type
-      include Dry::Equalizer(:type, :options, :rule, :meta)
+      include Dry::Equalizer(:type, :options, :rule, :meta, inspect: false)
       include Decorator
       include Builder
 

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -3,7 +3,7 @@ require 'dry/types/fn_container'
 module Dry
   module Types
     class Constructor < Definition
-      include Dry::Equalizer(:type, :options, :meta)
+      include Dry::Equalizer(:type, :options, :meta, inspect: false)
 
       # @return [#call]
       attr_reader :fn

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -4,12 +4,12 @@ module Dry
   module Types
     class Default
       include Type
-      include Dry::Equalizer(:type, :options, :value)
+      include Dry::Equalizer(:type, :options, :value, inspect: false)
       include Decorator
       include Builder
 
       class Callable < Default
-        include Dry::Equalizer(:type, :options)
+        include Dry::Equalizer(:type, :options, inspect: false)
 
         # Evaluates given callable
         # @return [Object]

--- a/lib/dry/types/definition.rb
+++ b/lib/dry/types/definition.rb
@@ -8,7 +8,7 @@ module Dry
       include Type
       include Options
       include Builder
-      include Dry::Equalizer(:primitive, :options, :meta)
+      include Dry::Equalizer(:primitive, :options, :meta, inspect: false)
 
       # @return [Class]
       attr_reader :primitive

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -4,7 +4,7 @@ module Dry
   module Types
     class Enum
       include Type
-      include Dry::Equalizer(:type, :options, :mapping)
+      include Dry::Equalizer(:type, :options, :mapping, inspect: false)
       include Decorator
 
       # @return [Array]
@@ -59,6 +59,13 @@ module Dry
                  mapping,
                  meta ? self.meta : EMPTY_HASH]]
       end
+
+      # @return [String]
+      # @api public
+      def to_s
+        PRINTER.(self)
+      end
+      alias_method :inspect, :to_s
 
       private
 

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -60,6 +60,16 @@ module Dry
       end
     end
 
+    class Printer
+      MAPPING[Maybe] = :visit_maybe
+
+      def visit_maybe(type, out)
+        out << "Maybe<"
+        visit(type.type, out)
+        out << ">"
+      end
+    end
+
     # Register non-coercible maybe types
     NON_NIL.each_key do |name|
       register("maybe.strict.#{name}", self["strict.#{name}"].maybe)

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -5,7 +5,7 @@ module Dry
   module Types
     class Maybe
       include Type
-      include Dry::Equalizer(:type, :options)
+      include Dry::Equalizer(:type, :options, inspect: false)
       include Decorator
       include Builder
       include Dry::Monads::Maybe::Mixin

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -63,10 +63,10 @@ module Dry
     class Printer
       MAPPING[Maybe] = :visit_maybe
 
-      def visit_maybe(type, out)
-        out << "Maybe<"
-        visit(type.type, out)
-        out << ">"
+      def visit_maybe(maybe)
+        visit(maybe.type) do |type|
+          yield "Maybe<#{ type }>"
+        end
       end
     end
 

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -70,6 +70,13 @@ module Dry
         ::Dry::Types::Hash::Constructor
       end
 
+      # Whether the type transforms types of schemas created by {Dry::Types::Hash#schema}
+      # @return [Bool]
+      # @api public
+      def transform_types?
+        !meta[:type_transform_fn].nil?
+      end
+
       private
 
       # @api private

--- a/lib/dry/types/hash/schema.rb
+++ b/lib/dry/types/hash/schema.rb
@@ -137,8 +137,14 @@ module Dry
           meta(key_transform_fn: handle)
         end
 
+        # Whether the schema transforms input keys
+        # @return [Bool]
+        # @api public
+        def trasform_keys?
+          !meta[:key_transform_fn].nil?
+        end
 
-        # @overload schmea(type_map, meta = EMPTY_HASH)
+        # @overload schema(type_map, meta = EMPTY_HASH)
         #   @param [{Symbol => Dry::Types::Definition}] type_map
         #   @param [Hash] meta
         #   @return [Dry::Types::Hash::Schema]

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -181,7 +181,7 @@ module Dry
         hash_output << meta(type, exclude: %i(type_transform_fn))
 
         if hash_output.empty?
-          out
+          out << "Hash"
         else
           out << "Hash<#{ hash_output }>"
         end

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -1,116 +1,164 @@
 module Dry
   module Types
     class Printer
+      MAPPING = {
+        Dry::Types::Definition => :visit_definition,
+        Dry::Types::Constructor => :visit_constructor,
+        Dry::Types::Constrained => :visit_constrained,
+        Dry::Types::Hash::Schema => :visit_schema,
+        Dry::Types::Hash::Key => :visit_key,
+        Dry::Types::Map => :visit_map,
+        Dry::Types::Safe => :visit_safe,
+        Dry::Types::Enum => :visit_enum,
+        Dry::Types::Default => :visit_default,
+        Dry::Types::Default::Callable => :visit_default,
+        Dry::Types::Sum => :visit_sum,
+        Dry::Types::Sum::Constrained => :visit_sum,
+      }
+
       def call(type)
         str = "#<Dry::Types["
         visit(type, str)
         str << "]>"
-        str
       end
 
       def visit(type, out)
-        case type
-        when Constructor
-          out << "Constructor<"
+        send(MAPPING.fetch(type.class), type, out)
+        out << ">"
+      end
 
-          visit(type.type, out)
-          visit_callable(type.fn, out << " fn=")
+      def visit_constructor(type, out)
+        out << "Constructor<"
 
-          out << options(type, exclude: %i(fn))
-          out << meta(type)
-        when Constrained
-          out << "Constrained<"
-          visit(type.type, out)
+        visit(type.type, out)
+        visit_callable(type.fn, out << " fn=")
 
-          rule = type.rule.to_s
+        out << options(type, exclude: %i(fn))
+        out << meta(type)
+      end
 
-          out << " rule=[#{ rule }]"
+      def visit_constrained(type, out)
+        out << "Constrained<"
+        visit(type.type, out)
 
-          out << options(type, exclude: %i(rule))
-          out << meta(type)
-        when Hash::Schema
-          out << "Schema<keys={" << type.map { |key, index|
-            key_out = ""
-            visit(key, key_out)
-            key_out
-          }.join(", ") << "}"
+        rule = type.rule.to_s
 
-          out << " strict" if type.strict?
+        out << " rule=[#{ rule }]"
 
-          if type.trasform_keys?
-            visit_callable(type.meta[:key_transform_fn], out << " key_fn=")
-          end
+        out << options(type, exclude: %i(rule))
+        out << meta(type)
+      end
 
-          if type.transform_types?
-            visit_callable(type.meta[:type_transform_fn], out << " type_fn=")
-          end
-
-          out << options(type, exclude: %i(keys))
-          out << meta(type, exclude: %i(strict key_transform_fn type_transform_fn))
-        when Map
-          out << "Map<"
-          visit(type.key_type, out)
-          out << " => "
-          visit(type.value_type, out)
-          out << options(type, exclude: %i(key_type value_type))
-          out << meta(type)
-        when Hash::Key
+      def visit_schema(type, out)
+        out << "Schema<keys={" << type.map { |key, index|
           key_out = ""
-          visit(type.type, key_out)
-          key_out.chomp!(">")
+          visit(key, key_out)
+          key_out
+        }.join(", ") << "}"
 
-          if type.required?
-            out << "#{ type.name }: #{ key_out }"
-          else
-            out << "#{ type.name }?: #{ key_out }"
-          end
-          out << meta(type)
-        when Sum, Sum::Constrained
-          out << "Sum<"
-          visit_sum(type, out)
-          out << options(type)
-          out << meta(type)
-        when Enum
-          out << "Enum<"
-          visit(type.type, out)
+        out << " strict" if type.strict?
 
-          if type.mapping == type.inverted_mapping
-            out << " values={"
-            out << type.mapping.values.map(&:inspect).join(", ")
-            out << "}"
-          else
-            out << " mapping={"
-            out << type.mapping.map { |key, value|
-              "#{ key.inspect }=>#{ value.inspect }"
-            }.join(", ")
-            out << "}"
-          end
-          out << options(type, exclude: %i(mapping))
-          out << meta(type)
-        when Default
-          out << "Default<"
-          visit(type.type, out)
-
-          if type.is_a?(Default::Callable)
-            visit_callable(type.value, out << " value_fn=")
-          else
-            out << " value=#{ type.value.inspect }"
-          end
-
-          out << options(type)
-          out << meta(type, exclude: %i(strict))
-        when Definition
-          out << "Definition<#{ type.primitive }"
-          out << options(type)
-          out << meta(type, exclude: %i(strict))
-        when Safe
-          out << "Safe<"
-          visit(type.type, out)
-        else
-          out << "unhandled"
+        if type.trasform_keys?
+          visit_callable(type.meta[:key_transform_fn], out << " key_fn=")
         end
 
-        out << ">"
+        if type.transform_types?
+          visit_callable(type.meta[:type_transform_fn], out << " type_fn=")
+        end
+
+        out << options(type, exclude: %i(keys))
+        out << meta(type, exclude: %i(strict key_transform_fn type_transform_fn))
+      end
+
+      def visit_map(type, out)
+        out << "Map<"
+        visit(type.key_type, out)
+        out << " => "
+        visit(type.value_type, out)
+        out << options(type, exclude: %i(key_type value_type))
+        out << meta(type)
+      end
+
+      def visit_key(type, out)
+        key_out = ""
+        visit(type.type, key_out)
+        key_out.chomp!(">")
+
+        if type.required?
+          out << "#{ type.name }: #{ key_out }"
+        else
+          out << "#{ type.name }?: #{ key_out }"
+        end
+        out << meta(type)
+      end
+
+      def visit_sum(type, out)
+        out << "Sum<"
+        visit_sum_constructors(type, out)
+        out << options(type)
+        out << meta(type)
+      end
+
+      def visit_sum_constructors(type, out)
+        case type.left
+        when Sum, Sum::Constrained
+          visit_sum_constructors(type.left, out)
+        else
+          visit(type.left, out)
+        end
+
+        out << " | "
+
+        case type.right
+        when Sum, Sum::Constrained
+          visit_sum_constructors(type.right, out)
+        else
+          visit(type.right, out)
+        end
+      end
+
+      def visit_enum(type, out)
+        out << "Enum<"
+        visit(type.type, out)
+
+        if type.mapping == type.inverted_mapping
+          out << " values={"
+          out << type.mapping.values.map(&:inspect).join(", ")
+          out << "}"
+        else
+          out << " mapping={"
+          out << type.mapping.map { |key, value|
+            "#{ key.inspect }=>#{ value.inspect }"
+          }.join(", ")
+          out << "}"
+        end
+        out << options(type, exclude: %i(mapping))
+        out << meta(type)
+      end
+
+      def visit_default(type, out)
+        out << "Default<"
+        visit(type.type, out)
+
+        if type.is_a?(Default::Callable)
+          visit_callable(type.value, out << " value_fn=")
+        else
+          out << " value=#{ type.value.inspect }"
+        end
+
+        out << options(type)
+        out << meta(type, exclude: %i(strict))
+      end
+
+      def visit_definition(type, out)
+        out << "Definition<#{ type.primitive }"
+        out << options(type)
+        out << meta(type, exclude: %i(strict))
+      end
+
+      def visit_safe(type, out)
+        out << "Safe<"
+        visit(type.type, out)
       end
 
       def options(type, exclude: EMPTY_ARRAY)
@@ -121,24 +169,6 @@ module Dry
           EMPTY_STRING
         else
           " options=#{ options.inspect }"
-        end
-      end
-
-      def visit_sum(type, out)
-        case type.left
-        when Sum, Sum::Constrained
-          visit_sum(type.left, out)
-        else
-          visit(type.left, out)
-        end
-
-        out << " | "
-
-        case type.right
-        when Sum, Sum::Constrained
-          visit_sum(type.right, out)
-        else
-          visit(type.right, out)
         end
       end
 
@@ -186,5 +216,7 @@ module Dry
         end
       end
     end
+
+    PRINTER = Printer.new.freeze
   end
 end

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module Dry
   module Types
+    # @api private
     class Printer
       MAPPING = {
         Definition => :visit_definition,
@@ -22,9 +25,7 @@ module Dry
       }
 
       def call(type)
-        str = "#<Dry::Types["
-        visit(type, str)
-        str << "]>"
+        "#<Dry::Types[#{ visit(type, "".dup) }]>"
       end
 
       def visit(type, out)
@@ -39,9 +40,7 @@ module Dry
       end
 
       def visit_array(type, out)
-        out << "Array<"
-        visit(type.member, out)
-        out << ">"
+        out << "Array<#{ visit(type.member, "".dup) }>"
       end
 
       def visit_constructor(type, out)
@@ -50,9 +49,7 @@ module Dry
         visit(type.type, out)
         visit_callable(type.fn, out << " fn=")
 
-        out << options(type, exclude: %i(fn))
-        out << meta(type)
-        out << ">"
+        out << options(type, exclude: %i(fn)) << meta(type) << ">"
       end
 
       def visit_constrained(type, out)
@@ -62,18 +59,11 @@ module Dry
         rule = type.rule.to_s
 
         out << " rule=[#{ rule }]"
-
-        out << options(type, exclude: %i(rule))
-        out << meta(type)
-        out << ">"
+        out << options(type, exclude: %i(rule)) << meta(type) << ">"
       end
 
       def visit_schema(type, out)
-        out << "Schema<keys={" << type.map { |key, index|
-          key_out = ""
-          visit(key, key_out)
-          key_out
-        }.join(", ") << "}"
+        out << "Schema<keys={" << type.map { |key| visit(key, "".dup) }.join(", ") << "}"
 
         out << " strict" if type.strict?
 
@@ -95,31 +85,24 @@ module Dry
         visit(type.key_type, out)
         out << " => "
         visit(type.value_type, out)
-        out << options(type, exclude: %i(key_type value_type))
-        out << meta(type)
-        out << ">"
+        out << options(type, exclude: %i(key_type value_type)) << meta(type) << ">"
       end
 
       def visit_key(type, out)
-        key_out = ""
-        visit(type.type, key_out)
-        key_out.chomp!(">")
+        key_out = visit(type.type, "".dup).chomp!(">")
 
         if type.required?
           out << "#{ type.name }: #{ key_out }"
         else
           out << "#{ type.name }?: #{ key_out }"
         end
-        out << meta(type)
-        out << ">"
+        out << meta(type) << ">"
       end
 
       def visit_sum(type, out)
         out << "Sum<"
         visit_sum_constructors(type, out)
-        out << options(type)
-        out << meta(type)
-        out << ">"
+        out << options(type) << meta(type) << ">"
       end
 
       def visit_sum_constructors(type, out)
@@ -170,26 +153,20 @@ module Dry
           out << " value=#{ type.value.inspect }"
         end
 
-        out << options(type)
-        out << meta(type, exclude: %i(strict))
-        out << ">"
+        out << options(type) << meta(type, exclude: %i(strict)) << ">"
       end
 
       def visit_definition(type, out)
         out << "Definition<#{ type.primitive }"
-        out << options(type)
-        out << meta(type, exclude: %i(strict))
-        out << ">"
+        out << options(type) << meta(type, exclude: %i(strict)) << ">"
       end
 
       def visit_safe(type, out)
-        out << "Safe<"
-        visit(type.type, out)
-        out << ">"
+        out << "Safe<#{ visit(type.type, "".dup) }>"
       end
 
       def visit_hash(type, out)
-        hash_output = ""
+        hash_output = "".dup
 
         if type.transform_types?
           visit_callable(type.meta[:type_transform_fn], hash_output << " type_fn=")
@@ -244,7 +221,7 @@ module Dry
           if meta.empty?
             EMPTY_STRING
           else
-            meta_str = " meta={"
+            meta_str = " meta={".dup
 
             values = type.meta.map do |key, value|
               case key

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -14,7 +14,8 @@ module Dry
         Hash::Schema => :visit_schema,
         Hash::Key => :visit_key,
         Map => :visit_map,
-        Array::Member => :visit_array,
+        Array => :visit_array,
+        Array::Member => :visit_array_member,
         Safe => :visit_safe,
         Enum => :visit_enum,
         Default => :visit_default,
@@ -40,6 +41,10 @@ module Dry
       end
 
       def visit_array(type, out)
+        out << "Array"
+      end
+
+      def visit_array_member(type, out)
         out << "Array<#{ visit(type.member, "".dup) }>"
       end
 

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -1,0 +1,190 @@
+module Dry
+  module Types
+    class Printer
+      def call(type)
+        str = "#<Dry::Types["
+        visit(type, str)
+        str << "]>"
+        str
+      end
+
+      def visit(type, out)
+        case type
+        when Constructor
+          out << "Constructor<"
+
+          visit(type.type, out)
+          visit_callable(type.fn, out << " fn=")
+
+          out << options(type, exclude: %i(fn))
+          out << meta(type)
+        when Constrained
+          out << "Constrained<"
+          visit(type.type, out)
+
+          rule = type.rule.to_s
+
+          out << " rule=[#{ rule }]"
+
+          out << options(type, exclude: %i(rule))
+          out << meta(type)
+        when Hash::Schema
+          out << "Schema<keys={" << type.map { |key, index|
+            key_out = ""
+            visit(key, key_out)
+            key_out
+          }.join(", ") << "}"
+
+          out << " strict" if type.strict?
+
+          if type.trasform_keys?
+            visit_callable(type.meta[:key_transform_fn], out << " key_fn=")
+          end
+
+          if type.transform_types?
+            visit_callable(type.meta[:type_transform_fn], out << " type_fn=")
+          end
+
+          out << options(type, exclude: %i(keys))
+          out << meta(type, exclude: %i(strict key_transform_fn type_transform_fn))
+        when Map
+          out << "Map<"
+          visit(type.key_type, out)
+          out << " => "
+          visit(type.value_type, out)
+          out << options(type, exclude: %i(key_type value_type))
+          out << meta(type)
+        when Hash::Key
+          key_out = ""
+          visit(type.type, key_out)
+          key_out.chomp!(">")
+
+          if type.required?
+            out << "#{ type.name }: #{ key_out }"
+          else
+            out << "#{ type.name }?: #{ key_out }"
+          end
+          out << meta(type)
+        when Sum, Sum::Constrained
+          out << "Sum<"
+          visit_sum(type, out)
+          out << options(type)
+          out << meta(type)
+        when Enum
+          out << "Enum<"
+          visit(type.type, out)
+
+          if type.mapping == type.inverted_mapping
+            out << " values={"
+            out << type.mapping.values.map(&:inspect).join(", ")
+            out << "}"
+          else
+            out << " mapping={"
+            out << type.mapping.map { |key, value|
+              "#{ key.inspect }=>#{ value.inspect }"
+            }.join(", ")
+            out << "}"
+          end
+          out << options(type, exclude: %i(mapping))
+          out << meta(type)
+        when Default
+          out << "Default<"
+          visit(type.type, out)
+
+          if type.is_a?(Default::Callable)
+            visit_callable(type.value, out << " value_fn=")
+          else
+            out << " value=#{ type.value.inspect }"
+          end
+
+          out << options(type)
+          out << meta(type, exclude: %i(strict))
+        when Definition
+          out << "Definition<#{ type.primitive }"
+          out << options(type)
+          out << meta(type, exclude: %i(strict))
+        when Safe
+          out << "Safe<"
+          visit(type.type, out)
+        else
+          out << "unhandled"
+        end
+
+        out << ">"
+      end
+
+      def options(type, exclude: EMPTY_ARRAY)
+        options = type.options.dup
+        exclude.each { |key| options.delete(key) }
+
+        if options.empty?
+          EMPTY_STRING
+        else
+          " options=#{ options.inspect }"
+        end
+      end
+
+      def visit_sum(type, out)
+        case type.left
+        when Sum, Sum::Constrained
+          visit_sum(type.left, out)
+        else
+          visit(type.left, out)
+        end
+
+        out << " | "
+
+        case type.right
+        when Sum, Sum::Constrained
+          visit_sum(type.right, out)
+        else
+          visit(type.right, out)
+        end
+      end
+
+      def visit_callable(fn, out)
+        case fn
+        when Method
+          out << "#{ fn.receiver }.#{ fn.name }"
+        when Proc
+          path, line = fn.source_location
+
+          if path
+            out << "#{ path.sub(Dir.pwd + "/", EMPTY_STRING) }:#{ line }"
+          elsif fn.lambda?
+            out << "(lambda)"
+          else
+            out << "(proc)"
+          end
+        else
+          out << "#{ fn.to_s }.call"
+        end
+      end
+
+      def meta(type, exclude: EMPTY_ARRAY)
+        if type.meta.empty?
+          EMPTY_STRING
+        else
+          meta = type.meta.reject { |k, _| exclude.include?(k) }
+
+          if meta.empty?
+            EMPTY_STRING
+          else
+            meta_str = " meta={"
+
+            values = type.meta.map do |key, value|
+              case key
+              when Symbol
+                "#{ key }: #{ value.inspect }"
+              else
+                "#{ key.inspect }=>#{ value.inspect }"
+              end
+            end
+
+            meta_str << values.join(", ") << "}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/types/result.rb
+++ b/lib/dry/types/result.rb
@@ -3,7 +3,7 @@ require 'dry/equalizer'
 module Dry
   module Types
     class Result
-      include Dry::Equalizer(:input)
+      include Dry::Equalizer(:input, inspect: false)
 
       # @return [Object]
       attr_reader :input
@@ -26,7 +26,7 @@ module Dry
       end
 
       class Failure < Result
-        include Dry::Equalizer(:input, :error)
+        include Dry::Equalizer(:input, :error, inspect: false)
 
         # @return [#to_s]
         attr_reader :error

--- a/lib/dry/types/safe.rb
+++ b/lib/dry/types/safe.rb
@@ -4,7 +4,7 @@ module Dry
   module Types
     class Safe
       include Type
-      include Dry::Equalizer(:type)
+      include Dry::Equalizer(:type, inspect: false)
       include Decorator
       include Builder
       private :options, :meta

--- a/lib/dry/types/spec/types.rb
+++ b/lib/dry/types/spec/types.rb
@@ -38,6 +38,14 @@ RSpec.shared_examples_for 'Dry::Types::Definition without primitive' do
       expect(type.optional?).to be_boolean
     end
   end
+
+  describe '#to_s' do
+    it 'returns a custom string representation' do
+      if type.class.name.start_with?('Dry::Types')
+        expect(type.to_s).to start_with('#<Dry::Types')
+      end
+    end
+  end
 end
 
 RSpec.shared_examples_for 'Dry::Types::Definition#meta' do

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -4,7 +4,7 @@ module Dry
   module Types
     class Sum
       include Type
-      include Dry::Equalizer(:left, :right, :options, :meta)
+      include Dry::Equalizer(:left, :right, :options, :meta, inspect: false)
       include Builder
       include Options
 

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -97,4 +97,12 @@ RSpec.describe Dry::Types::Array do
       end
     end
   end
+
+  describe '#to_s' do
+    subject(:type) { Dry::Types['array'].of(Dry::Types['string']) }
+
+    it 'returns string representation of the type' do
+      expect(type.to_s).to eql('#<Dry::Types[Array<Definition<String>>]>')
+    end
+  end
 end

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -98,11 +98,21 @@ RSpec.describe Dry::Types::Array do
     end
   end
 
+  context 'member' do
+    describe '#to_s' do
+      subject(:type) { Dry::Types['array'].of(Dry::Types['string']) }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).to eql('#<Dry::Types[Array<Definition<String>>]>')
+      end
+    end
+  end
+
   describe '#to_s' do
-    subject(:type) { Dry::Types['array'].of(Dry::Types['string']) }
+    subject(:type) { Dry::Types['array'] }
 
     it 'returns string representation of the type' do
-      expect(type.to_s).to eql('#<Dry::Types[Array<Definition<String>>]>')
+      expect(type.to_s).to eql('#<Dry::Types[Array]>')
     end
   end
 end

--- a/spec/dry/types/constrained_spec.rb
+++ b/spec/dry/types/constrained_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe Dry::Types::Constrained do
     end
   end
 
+  describe '#to_s' do
+    subject(:type) do
+      Dry::Types['strict.string'].constrained(size: 3..12)
+    end
+
+    it 'returns string representation of the type' do
+      expect(type.to_s).
+        to eql(
+            "#<Dry::Types[Constrained<Definition<String> "\
+            "rule=[type?(String) AND size?(3..12)]>]>"
+          )
+    end
+  end
+
   context 'with a constructor type' do
     subject(:type) do
       Dry::Types['coercible.hash'].constrained(size: 1)

--- a/spec/dry/types/constructor_spec.rb
+++ b/spec/dry/types/constructor_spec.rb
@@ -234,4 +234,13 @@ RSpec.describe Dry::Types::Constructor do
       expect(type.method(:>>)).to eql(type.method(:append))
     end
   end
+
+  describe '#to_s' do
+    subject(:type) { Dry::Types['coercible.integer'] }
+
+    it 'returns string representation of the type' do
+      expect(type.to_s).
+        to eql("#<Dry::Types[Constructor<Definition<Integer> fn=Kernel.Integer>]>")
+    end
+  end
 end

--- a/spec/dry/types/constructor_spec.rb
+++ b/spec/dry/types/constructor_spec.rb
@@ -236,11 +236,30 @@ RSpec.describe Dry::Types::Constructor do
   end
 
   describe '#to_s' do
-    subject(:type) { Dry::Types['coercible.integer'] }
+    context 'method object' do
+      subject(:type) { Dry::Types['coercible.integer'] }
 
-    it 'returns string representation of the type' do
-      expect(type.to_s).
-        to eql("#<Dry::Types[Constructor<Definition<Integer> fn=Kernel.Integer>]>")
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql("#<Dry::Types[Constructor<Definition<Integer> fn=Kernel.Integer>]>")
+      end
+    end
+
+    context 'callable object with .call defined in class' do
+      before do
+        class Test::IntegerConstructor
+          def call
+            5
+          end
+        end
+      end
+
+      subject(:type) { Dry::Types['integer'].constructor(Test::IntegerConstructor.new) }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql("#<Dry::Types[Constructor<Definition<Integer> fn=Test::IntegerConstructor#call>]>")
+      end
     end
   end
 end

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -165,4 +165,80 @@ RSpec.describe Dry::Types::Definition, '#default' do
       end
     end
   end
+
+  describe '#to_s' do
+    context 'static valute' do
+      subject(:type) { Dry::Types['string'].default('foo') }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).to eql('#<Dry::Types[Default<Definition<String> value="foo">]>')
+      end
+    end
+
+    context 'callable value' do
+      subject(:type) { Dry::Types['string'].default(value_constructor) }
+
+      context 'proc' do
+        let(:value_constructor) { proc { 'foo' } }
+
+        let(:line_no) { value_constructor.source_location[1] }
+
+        it 'returns string representation of the type' do
+          expect(type.to_s).
+            to eql(
+              "#<Dry::Types[Default<Definition<String> "\
+              "value_fn=spec/dry/types/default_spec.rb:#{ line_no }>]>"
+            )
+        end
+      end
+
+      context 'proc w/o source' do
+        let(:value_constructor) { method(:Integer).to_proc }
+
+        it 'returns string representation of the type' do
+          expect(type.to_s).
+            to eql(
+              "#<Dry::Types[Default<Definition<String> "\
+              "value_fn=(lambda)>]>"
+            )
+        end
+      end
+
+      context 'method' do
+        let(:value_constructor) { Kernel.method(:Integer) }
+
+        it 'returns string representation of the type' do
+          expect(type.to_s).
+            to eql(
+              "#<Dry::Types[Default<Definition<String> "\
+              "value_fn=Kernel.Integer>]>"
+            )
+        end
+      end
+
+      context 'callable object' do
+        let(:value_constructor) do
+          obj = Object.new
+
+          def obj.to_s
+            "callable"
+          end
+
+          def obj.call(*)
+            5
+          end
+
+          obj
+        end
+
+        it 'returns string representation of the type' do
+          expect(type.to_s).
+            to eql(
+              "#<Dry::Types[Default<Definition<String> "\
+              "value_fn=callable.call>]>"
+            )
+        end
+      end
+    end
+  end
 end

--- a/spec/dry/types/definition_spec.rb
+++ b/spec/dry/types/definition_spec.rb
@@ -68,5 +68,13 @@ RSpec.describe Dry::Types::Definition do
         end
       end
     end
+
+    describe '#to_s' do
+      let(:type) { Dry::Types['string']  }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).to eql('#<Dry::Types[Definition<String>]>')
+      end
+    end
   end
 end

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -143,4 +143,30 @@ RSpec.describe Dry::Types::Enum do
       expect(enum_with_meta.meta).to eql(foo: :bar)
     end
   end
+
+  describe '#to_s' do
+    context 'simple enumeration' do
+      subject(:type) { Dry::Types['integer'].enum(4, 5, 6) }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql("#<Dry::Types[Enum<Constrained<Definition<Integer> "\
+                 "rule=[included_in?([4, 5, 6])]> values={4, 5, 6}>]>")
+      end
+    end
+
+    context 'mapping' do
+      let(:mapping) { {0 => 'draft', 10 => 'published', 20 => 'archived'} }
+
+      subject(:type) { Dry::Types['integer'].enum(mapping) }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql('#<Dry::Types[Enum<Constrained<Definition<Integer> '\
+                 'rule=[included_in?([0, 10, 20])]> '\
+                 'mapping={0=>"draft", 10=>"published", 20=>"archived"}>]>'
+                 )
+      end
+    end
+  end
 end

--- a/spec/dry/types/hash_spec.rb
+++ b/spec/dry/types/hash_spec.rb
@@ -39,4 +39,10 @@ RSpec.describe Dry::Types::Hash do
       expect { map.('foo' => '2') }.to raise_error(Dry::Types::MapError)
     end
   end
+
+  describe '#to_s' do
+    it 'returns string representation of the type' do
+      expect(type.to_s).to eql('#<Dry::Types[Hash]>')
+    end
+  end
 end

--- a/spec/dry/types/map_spec.rb
+++ b/spec/dry/types/map_spec.rb
@@ -188,4 +188,13 @@ RSpec.describe Dry::Types::Map do
       end
     end
   end
+
+  describe '#to_s' do
+    subject(:type) { Dry::Types['hash'].map('string', 'integer') }
+
+    it 'returns string representation of the type' do
+      expect(type.to_s).
+        to eql('#<Dry::Types[Map<Definition<String> => Definition<Integer>>]>')
+    end
+  end
 end

--- a/spec/dry/types/safe_spec.rb
+++ b/spec/dry/types/safe_spec.rb
@@ -32,4 +32,13 @@ RSpec.describe Dry::Types::Definition, '#safe' do
       expect(type[age: 'wat', active: '1']).to eql(age: 'wat', active: true)
     end
   end
+
+  describe '#to_s' do
+    subject(:type) { Dry::Types['coercible.integer'].safe }
+
+    it 'returns string representation of the type' do
+      expect(type.to_s).
+        to eql("#<Dry::Types[Safe<Constructor<Definition<Integer> fn=Kernel.Integer>>]>")
+    end
+  end
 end

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -336,26 +336,22 @@ RSpec.describe Dry::Types::Hash::Schema do
     context 'key transformation' do
       let(:key_transformation) { :to_sym.to_proc }
 
-      let(:transformation_name) { Dry::Types::FnContainer.register_name(key_transformation) }
-
       subject(:type) { Dry::Types['hash'].schema({}).with_key_transform(key_transformation) }
 
       it 'returns string representation of the type' do
         expect(type.to_s).
-          to eql("#<Dry::Types[Schema<keys={} key_fn=#{ transformation_name }.call>]>")
+          to eql("#<Dry::Types[Schema<keys={} key_fn=.to_sym>]>")
       end
     end
 
     context 'type transformation' do
       let(:type_transformation) { :safe.to_proc }
 
-      let(:transformation_name) { Dry::Types::FnContainer.register_name(type_transformation) }
-
       subject(:type) { Dry::Types['hash'].with_type_transform(type_transformation).schema({}) }
 
       it 'returns string representation of the type' do
         expect(type.to_s).
-          to eql("#<Dry::Types[Schema<keys={} type_fn=#{ transformation_name }.call>]>")
+          to eql("#<Dry::Types[Schema<keys={} type_fn=.safe>]>")
       end
     end
 

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -317,50 +317,52 @@ RSpec.describe Dry::Types::Hash::Schema do
   end
 
   describe '#to_s' do
-    context 'empty schema' do
-      subject(:type) { Dry::Types['hash'].schema({}) }
+    context 'inline' do
+      context 'empty schema' do
+        subject(:type) { Dry::Types['hash'].schema({}) }
 
-      it 'returns string representation of the type' do
-        expect(type.to_s).to eql('#<Dry::Types[Schema<keys={}>]>')
+        it 'returns string representation of the type' do
+          expect(type.to_s).to eql('#<Dry::Types[Schema<keys={}>]>')
+        end
       end
-    end
 
-    context 'strict schema' do
-      subject(:type) { Dry::Types['hash'].schema({}).strict }
+      context 'strict schema' do
+        subject(:type) { Dry::Types['hash'].schema({}).strict }
 
-      it 'returns string representation of the type' do
-        expect(type.to_s).to eql('#<Dry::Types[Schema<keys={} strict>]>')
+        it 'returns string representation of the type' do
+          expect(type.to_s).to eql('#<Dry::Types[Schema<strict keys={}>]>')
+        end
       end
-    end
 
-    context 'key transformation' do
-      let(:key_transformation) { :to_sym.to_proc }
+      context 'key transformation' do
+        let(:key_transformation) { :to_sym.to_proc }
 
-      subject(:type) { Dry::Types['hash'].schema({}).with_key_transform(key_transformation) }
+        subject(:type) { Dry::Types['hash'].schema({}).with_key_transform(key_transformation) }
 
-      it 'returns string representation of the type' do
-        expect(type.to_s).
-          to eql("#<Dry::Types[Schema<keys={} key_fn=.to_sym>]>")
+        it 'returns string representation of the type' do
+          expect(type.to_s).
+            to eql("#<Dry::Types[Schema<key_fn=.to_sym keys={}>]>")
+        end
       end
-    end
 
-    context 'type transformation' do
-      let(:type_transformation) { :safe.to_proc }
+      context 'type transformation' do
+        let(:type_transformation) { :safe.to_proc }
 
-      subject(:type) { Dry::Types['hash'].with_type_transform(type_transformation).schema({}) }
+        subject(:type) { Dry::Types['hash'].with_type_transform(type_transformation).schema({}) }
 
-      it 'returns string representation of the type' do
-        expect(type.to_s).
-          to eql("#<Dry::Types[Schema<keys={} type_fn=.safe>]>")
+        it 'returns string representation of the type' do
+          expect(type.to_s).
+            to eql("#<Dry::Types[Schema<type_fn=.safe keys={}>]>")
+        end
       end
-    end
 
-    context 'schema with keys' do
-      subject(:type) { Dry::Types['hash'].schema(name: 'string', age?: 'integer') }
+      context 'schema with keys' do
+        subject(:type) { Dry::Types['hash'].schema(name: 'string', age?: 'integer') }
 
-      it 'returns string representation of the type' do
-        expect(type.to_s).
-          to eql("#<Dry::Types[Schema<keys={name: Definition<String>, age?: Definition<Integer>}>]>")
+        it 'returns string representation of the type' do
+          expect(type.to_s).
+            to eql("#<Dry::Types[Schema<keys={name: Definition<String> age?: Definition<Integer>}>]>")
+        end
       end
     end
   end

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -315,4 +315,57 @@ RSpec.describe Dry::Types::Hash::Schema do
       end
     end
   end
+
+  describe '#to_s' do
+    context 'empty schema' do
+      subject(:type) { Dry::Types['hash'].schema({}) }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).to eql('#<Dry::Types[Schema<keys={}>]>')
+      end
+    end
+
+    context 'strict schema' do
+      subject(:type) { Dry::Types['hash'].schema({}).strict }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).to eql('#<Dry::Types[Schema<keys={} strict>]>')
+      end
+    end
+
+    context 'key transformation' do
+      let(:key_transformation) { :to_sym.to_proc }
+
+      let(:transformation_name) { Dry::Types::FnContainer.register_name(key_transformation) }
+
+      subject(:type) { Dry::Types['hash'].schema({}).with_key_transform(key_transformation) }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql("#<Dry::Types[Schema<keys={} key_fn=#{ transformation_name }.call>]>")
+      end
+    end
+
+    context 'type transformation' do
+      let(:type_transformation) { :safe.to_proc }
+
+      let(:transformation_name) { Dry::Types::FnContainer.register_name(type_transformation) }
+
+      subject(:type) { Dry::Types['hash'].with_type_transform(type_transformation).schema({}) }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql("#<Dry::Types[Schema<keys={} type_fn=#{ transformation_name }.call>]>")
+      end
+    end
+
+    context 'schema with keys' do
+      subject(:type) { Dry::Types['hash'].schema(name: 'string', age?: 'integer') }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql("#<Dry::Types[Schema<keys={name: Definition<String>, age?: Definition<Integer>}>]>")
+      end
+    end
+  end
 end

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -241,6 +241,34 @@ RSpec.describe Dry::Types::Sum do
     end
   end
 
+  describe '#to_s' do
+    context 'shallow sum' do
+      let(:type) { Dry::Types['string'] | Dry::Types['integer'] }
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).to eql('#<Dry::Types[Sum<Definition<String> | Definition<Integer>>]>')
+      end
+    end
+
+    context 'sum tree' do
+      let(:type) do
+        Dry::Types['string'] | Dry::Types['integer'] | (Dry::Types['date'] | Dry::Types['time'])
+      end
+
+      it 'returns string representation of the type' do
+        expect(type.to_s).
+          to eql(
+              '#<Dry::Types[Sum<'\
+              'Definition<String> | '\
+              'Definition<Integer> | '\
+              'Definition<Date> | '\
+              'Definition<Time>'\
+              '>]>'
+            )
+      end
+    end
+  end
+
   context 'with map type' do
     let(:map_type) { Dry::Types['strict.hash'].map(Dry::Types['strict.symbol'], Dry::Types['strict.string']) }
     let(:string_type) { Dry::Types['strict.string'] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,6 @@ require 'dry-types'
 
 begin
   require 'pry-byebug'
-  require 'mutant'
 
   module Mutant
     class Selector


### PR DESCRIPTION
Addresses #290 

This is a WIP. The goal is to print only what needs to be print. I disabled the default `inspect/to_s` implementation coming from dry-equalizer and replaced it with a custom traversing object.