### PR TITLE
Add option for ignoring missing keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
 
-gem 'dry-equalizer', github: 'dry-rb/dry-equalizer'
-
 group :test do
   platform :mri do
     gem 'simplecov', require: false

--- a/lib/dry/types/hash.rb
+++ b/lib/dry/types/hash.rb
@@ -69,7 +69,7 @@ module Dry
       end
 
       # Whether the type transforms types of schemas created by {Dry::Types::Hash#schema}
-      # @return [Bool]
+      # @return [Boolean]
       # @api public
       def transform_types?
         !options[:type_transform_fn].nil?

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -47,9 +47,10 @@ module Dry
       end
 
       # @param [Hash] hash
+      # @option options [Boolean] :skip_missing If true don't raise error if on missing keys
       # @return [Hash{Symbol => Object}]
-      def call(hash)
-        coerce(hash)
+      def call(hash, options = EMPTY_HASH)
+        coerce(hash, options)
       end
       alias_method :[], :call
 
@@ -145,7 +146,7 @@ module Dry
       end
 
       # Whether the schema transforms input keys
-      # @return [Bool]
+      # @return [Boolean]
       # @api public
       def trasform_keys?
         !options[:key_transform_fn].nil?
@@ -217,7 +218,7 @@ module Dry
           values
       end
 
-      def resolve(hash, &block)
+      def resolve(hash, options = EMPTY_HASH, &block)
         result = {}
 
         hash.each do |key, value|
@@ -231,19 +232,19 @@ module Dry
         end
 
         if result.size < keys.size
-          resolve_missing_keys(result, &block)
+          resolve_missing_keys(result, options, &block)
         end
 
         result
       end
 
-      def resolve_missing_keys(result)
+      def resolve_missing_keys(result, options)
         keys.each do |key|
           next if result.key?(key.name)
 
           if key.default?
             result[key.name] = yield(key, Undefined)
-          elsif key.required?
+          elsif key.required? && !options[:skip_missing]
             raise MissingKeyError, key.name
           end
         end
@@ -265,8 +266,8 @@ module Dry
 
       # @param [Hash] hash
       # @return [Hash{Symbol => Object}]
-      def coerce(hash)
-        resolve(hash) do |key, value|
+      def coerce(hash, options = EMPTY_HASH)
+        resolve(hash, options) do |key, value|
           begin
             key.(value)
           rescue ConstraintError => e

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -47,12 +47,18 @@ module Dry
       end
 
       # @param [Hash] hash
-      # @option options [Boolean] :skip_missing If true don't raise error if on missing keys
       # @return [Hash{Symbol => Object}]
-      def call(hash, options = EMPTY_HASH)
-        coerce(hash, options)
+      def call(hash)
+        coerce(hash)
       end
       alias_method :[], :call
+
+      # @param [Hash] hash
+      # @option options [Boolean] :skip_missing If true don't raise error if on missing keys
+      # @return [Hash{Symbol => Object}]
+      def apply(hash, options = EMPTY_HASH)
+        coerce(hash, options)
+      end
 
       # @param [Hash] hash
       # @yieldparam [Failure] failure

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -367,8 +367,8 @@ RSpec.describe Dry::Types::Schema do
     end
   end
 
-  describe '#call' do
-    context 'partial application' do
+  describe '#apply' do
+    context 'ignoring missing keys' do
       subject(:type) do
         Dry::Types['hash'].schema(
           name: 'coercible.string',
@@ -378,7 +378,7 @@ RSpec.describe Dry::Types::Schema do
       end
 
       it 'can be partially applied' do
-        expect(type.({ age: '18' }, skip_missing: true)).to eql(age: 18, city: 'New York')
+        expect(type.apply({ age: '18' }, skip_missing: true)).to eql(age: 18, city: 'New York')
       end
     end
   end

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -366,4 +366,20 @@ RSpec.describe Dry::Types::Schema do
       end
     end
   end
+
+  describe '#call' do
+    context 'partial application' do
+      subject(:type) do
+        Dry::Types['hash'].schema(
+          name: 'coercible.string',
+          age: 'coercible.integer',
+          city: Dry::Types['strict.string'].default('New York'.freeze)
+        )
+      end
+
+      it 'can be partially applied' do
+        expect(type.({ age: '18' }, skip_missing: true)).to eql(age: 18, city: 'New York')
+      end
+    end
+  end
 end


### PR DESCRIPTION
It'll be useful for dry-struct where new struct can be created based on existing ones. Now we can check only new keys and skip type application for previously existed.