### PR TITLE
CI: Use latest Rubies, drop sudo: false setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 bundler_args: --without benchmarks tools
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -11,8 +10,8 @@ after_script:
 script:
   - bundle exec rake
 rvm:
-  - 2.6.1
-  - 2.5.3
+  - 2.6.2
+  - 2.5.5
   - 2.4.5
   - jruby-9.2.6.0
 env:


### PR DESCRIPTION
Updates the matrix to use latest Rubies.

Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration