### PR TITLE
CI: latest jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - 2.6.2
   - 2.5.5
   - 2.4.6
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
 env:
   global:
     - COVERAGE=true


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)