### PR TITLE
Handle all errors consistently

### DIFF
--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -83,7 +83,10 @@ module Dry
       # @param (see Failure#initialize)
       # @return [Result::Failure]
       def failure(input, error)
-        Result::Failure.new(input, CoercionError[error])
+        unless error.is_a?(CoercionError)
+          raise ArgumentError, "error must be a CoercionError"
+        end
+        Result::Failure.new(input, error)
       end
 
       # Checks whether value is of a #primitive class
@@ -112,7 +115,10 @@ module Dry
         result = success(input)
 
         coerce(input) do
-          result = failure(input, "#{input.inspect} must be an instance of #{primitive}")
+          result = failure(
+            input,
+            CoercionError.new("#{input.inspect} must be an instance of #{primitive}")
+          )
         end
 
         if block_given?

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -85,17 +85,23 @@ module Dry
           end
 
           success &&= primitive?(result)
+
+          if success
+            failure = nil
+          else
+            error = CoercionError.new("#{input} doesn't conform schema", meta: result)
+            failure = failure(output, error)
+          end
         else
-          success = false
-          output = input
-          result = CoercionError["#{input} must be a hash"]
+          failure = failure(input, CoercionError.new("#{input} must be a hash"))
         end
 
-        if success
+        if failure.nil?
           success(output)
+        elsif block_given?
+          yield(failure)
         else
-          failure = failure(output, result)
-          block_given? ? yield(failure) : failure
+          failure
         end
       end
 

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -203,10 +203,9 @@ RSpec.describe Dry::Types::Schema do
       expect { |rspec_probe| hash.try(input, &rspec_probe) }
         .to yield_with_args(instance_of(Dry::Types::Result::Failure))
 
-      pending
       # assert that the failure result provides context for the failing input
       hash.try(input) do |failure|
-        expect(failure.error[:age].success?).to be(false)
+        expect(failure.error.meta[:age].success?).to be(false)
       end
     end
 


### PR DESCRIPTION
This brings sanity back to errors handling. I had to add some defensive programming in order to ensure all errors and failure objects have the same interface. It's possible to improve it further but even in this form it's 1000% better than before.