### PR TITLE
Performance improvements for constructor types

### DIFF
--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/types/fn_container'
-require 'dry/types/constructor/call'
+require 'dry/types/constructor/function'
 
 module Dry
   module Types
@@ -21,7 +21,7 @@ module Dry
       # @param [#call, nil] block
       def self.new(input, **options, &block)
         type = input.is_a?(Builder) ? input : Nominal.new(input)
-        super(type, **options, fn: Call[options.fetch(:fn, block)])
+        super(type, **options, fn: Function[options.fetch(:fn, block)])
       end
 
       # @param [Type] type

--- a/lib/dry/types/constructor/call.rb
+++ b/lib/dry/types/constructor/call.rb
@@ -1,0 +1,49 @@
+module Dry
+  module Types
+    class Constructor < Nominal
+      class Call
+        class Safe < Call
+          def call(input, &fallback)
+            super
+          rescue NoMethodError, TypeError, ArgumentError => error
+            CoercionError.handle(error, &fallback)
+          end
+        end
+
+        def self.[](fn, options = EMPTY_HASH)
+          raise ArgumentError, 'Missing constructor block' if fn.nil?
+
+          if fn.is_a?(Call)
+            fn
+          else
+            parameters = fn.respond_to?(:parameters) ? fn.parameters : fn.method(:call).parameters
+            *, (last_arg,) = parameters
+
+            if last_arg.equal?(:block)
+              new(fn)
+            else
+              Safe.new(fn)
+            end
+          end
+        end
+
+        include Dry::Equalizer(:fn)
+
+        attr_reader :fn
+
+        def initialize(fn)
+          @fn = fn
+        end
+
+        def call(input, &block)
+          @fn.(input, &block)
+        end
+        alias_method :[], :call
+
+        def to_ast
+          Dry::Types::FnContainer.register(fn)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/types/constructor/function.rb
+++ b/lib/dry/types/constructor/function.rb
@@ -1,19 +1,23 @@
 module Dry
   module Types
     class Constructor < Nominal
-      class Call
-        class Safe < Call
+      class Function
+        class Safe < Function
           def call(input, &fallback)
             super
           rescue NoMethodError, TypeError, ArgumentError => error
             CoercionError.handle(error, &fallback)
+          end
+
+          def wrapped?
+            true
           end
         end
 
         def self.[](fn, options = EMPTY_HASH)
           raise ArgumentError, 'Missing constructor block' if fn.nil?
 
-          if fn.is_a?(Call)
+          if fn.is_a?(Function)
             fn
           else
             parameters = fn.respond_to?(:parameters) ? fn.parameters : fn.method(:call).parameters
@@ -42,6 +46,10 @@ module Dry
 
         def to_ast
           Dry::Types::FnContainer.register(fn)
+        end
+
+        def wrapped?
+          false
         end
       end
     end

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -58,12 +58,12 @@ module Dry
 
       def visit_constructor(constructor)
         visit(constructor.type) do |type|
-          visit_callable(constructor.fn) do |fn|
+          visit_callable(constructor.fn.fn) do |fn|
             options = constructor.options.dup
             options.delete(:fn)
 
             visit_options(options, constructor.meta) do |opts|
-              yield "Constructor<#{ type } fn=#{ fn }#{ opts }>"
+              yield "Constructor<#{type} fn=#{fn}#{opts}>"
             end
           end
         end
@@ -75,7 +75,7 @@ module Dry
           rule = options.delete(:rule)
 
           visit_options(options, constrained.meta) do |opts|
-            yield "Constrained<#{ type } rule=[#{ rule.to_s }]>"
+            yield "Constrained<#{type} rule=[#{rule}]>"
           end
         end
       end
@@ -91,22 +91,22 @@ module Dry
 
         if key_fn = options.delete(:key_transform_fn)
           visit_callable(key_fn) do |fn|
-            key_fn_str = "key_fn=#{ fn } "
+            key_fn_str = "key_fn=#{fn} "
           end
         end
 
         if type_fn = options.delete(:type_transform_fn)
           visit_callable(type_fn) do |fn|
-            type_fn_str = "type_fn=#{ fn } "
+            type_fn_str = "type_fn=#{fn} "
           end
         end
 
         keys = options.delete(:keys)
 
         visit_options(options, schema.meta) do |opts|
-          schema_parameters = "#{ key_fn_str }#{ type_fn_str }#{ strict_str }#{ opts }"
+          schema_parameters = "#{key_fn_str}#{type_fn_str}#{strict_str}#{opts}"
 
-          header = "Schema<#{ schema_parameters }keys={"
+          header = "Schema<#{schema_parameters}keys={"
 
           if size.zero?
             yield "#{ header}}>"

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
 
     expect(type[:foo]).to eql('foo')
 
-    expect(type.fn).to be(fn)
+    expect(type.fn.fn).to be(fn)
     expect(type.primitive).to be(String)
   end
 
@@ -296,7 +296,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
 
     expect(type[:foo]).to eql('foo')
 
-    expect(type.fn).to be(fn)
+    expect(type.fn.fn).to be(fn)
     expect(type.primitive).to be(String)
     expect(type.meta).to eql(foo: :bar)
   end

--- a/spec/dry/types/constructor/function_spec.rb
+++ b/spec/dry/types/constructor/function_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe Dry::Types::Constructor::Function do
+  describe '.[]' do
+    shared_examples 'well-behaving coercion function' do
+      it 'applies constructor' do
+        expect(fun.('1')).to eql(1)
+      end
+
+      it 'rescues errors and re-throws them as coercion errors' do
+        expect { fun.('a') }.to raise_error(Dry::Types::CoercionError)
+      end
+
+      it 'extends accepts a fallback block' do
+        expect(fun.('a') { :fallback }).to be(:fallback)
+      end
+    end
+
+    context 'proc' do
+      include_examples 'well-behaving coercion function' do
+        subject(:fun) { described_class[proc { |value| Integer(value) }] }
+
+        specify { expect(fun).to be_wrapped }
+      end
+    end
+
+    context 'lambda' do
+      include_examples 'well-behaving coercion function' do
+        subject(:fun) { described_class[lambda { |value| Integer(value) }] }
+
+        specify { expect(fun).to be_wrapped }
+      end
+    end
+
+    context 'method' do
+      include_examples 'well-behaving coercion function' do
+        subject(:fun) { described_class[Kernel.method(:Integer)] }
+
+        specify { expect(fun).to be_wrapped }
+      end
+    end
+
+    context 'method with fallback' do
+      include_examples 'well-behaving coercion function' do
+        subject(:fun) do
+          obj = Object.new
+
+          def obj.coerce(value, &block)
+            Integer(value)
+          rescue ArgumentError => error
+            Dry::Types::CoercionError.handle(error, &block)
+          end
+
+          described_class[obj.method(:coerce)]
+        end
+
+        specify { expect(fun).not_to be_wrapped }
+      end
+    end
+
+    context 'callable object without fallback' do
+      include_examples 'well-behaving coercion function' do
+        subject(:fun) do
+          fn = Class.new {
+            def call(value)
+              Integer(value)
+            end
+          }.new
+
+          described_class[fn]
+        end
+
+        specify { expect(fun).to be_wrapped }
+      end
+    end
+
+    context 'callable object with fallback' do
+      include_examples 'well-behaving coercion function' do
+        subject(:fun) do
+          fn = Class.new {
+            def call(value, &block)
+              Integer(value)
+            rescue ArgumentError => error
+              Dry::Types::CoercionError.handle(error, &block)
+            end
+          }.new
+
+          described_class[fn]
+        end
+
+        specify { expect(fun).not_to be_wrapped }
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is possible to save some allocations along the way. For this, we'll need a first class representation of the constructor function.