### PR TITLE
Make AST represenation of constructor functions more precise

### DIFF
--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -29,10 +29,9 @@ module Dry
       end
 
       def visit_constructor(node)
-        nominal, fn_register_name, meta = node
-        fn = Dry::Types::FnContainer[fn_register_name]
+        nominal, fn, meta = node
         primitive = visit(nominal)
-        primitive.constructor(fn).meta(meta)
+        primitive.constructor(compile_fn(fn)).meta(meta)
       end
 
       def visit_lax(node)
@@ -114,6 +113,22 @@ module Dry
 
       def visit_any(meta)
         registry['any'].meta(meta)
+      end
+
+      def compile_fn(fn)
+        type, *node = fn
+
+        case type
+        when :id
+          Dry::Types::FnContainer[node.fetch(0)]
+        when :callable
+          node.fetch(0)
+        when :method
+          target, method = node
+          target.method(method)
+        else
+          raise ArgumentError, "Cannot build callable from #{fn.inspect}"
+        end
       end
     end
   end

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -239,19 +239,6 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     expect(array.member.primitive).to be(String)
   end
 
-  it 'builds a constructor' do
-    fn = -> v { v.to_s }
-
-    ast = Dry::Types::Constructor.new(String, &fn).to_ast
-
-    type = compiler.(ast)
-
-    expect(type[:foo]).to eql('foo')
-
-    expect(type.fn.fn).to be(fn)
-    expect(type.primitive).to be(String)
-  end
-
   it 'builds a strict type' do
     ast = Dry::Types['strict.string'].to_ast
 
@@ -353,5 +340,30 @@ RSpec.describe Dry::Types::Compiler, '#call' do
     expect(type.meta).to eql(foo: 'bar', abc: 123)
     expect(type.valid?({ 'x' => 5 })).to eql(true)
     expect(type.valid?({ 5 => 'x' })).to eql(false)
+  end
+
+  context 'constructors' do
+    example 'simple constructor' do
+      fn = -> v { v.to_s }
+
+      ast = Dry::Types::Constructor.new(String, &fn).to_ast
+
+      type = compiler.(ast)
+
+      expect(type[:foo]).to eql('foo')
+
+      expect(type.fn.fn).to be(fn)
+      expect(type.primitive).to be(String)
+    end
+
+    example 'built-in constructor type' do
+      source = Dry::Types['params.integer']
+      ast = source.to_ast
+
+      type = compiler.(ast)
+
+      expect(type).to eql(source)
+      expect(type.('1')).to eql(1)
+    end
   end
 end

--- a/spec/dry/types/constructor/function_spec.rb
+++ b/spec/dry/types/constructor/function_spec.rb
@@ -90,4 +90,46 @@ RSpec.describe Dry::Types::Constructor::Function do
       end
     end
   end
+
+  describe '#to_ast' do
+    subject(:function) { described_class[fn] }
+
+    context 'proc' do
+      let(:fn) { proc { |value| Integer(value) } }
+
+      specify do
+        expect(function.to_ast).to eql([:id, Dry::Types::FnContainer.register_name(fn)])
+      end
+    end
+
+    context 'method call' do
+      let(:fn) { 'foo'.method(:Integer) }
+
+      specify do
+        expect(function.to_ast).to eql([:method, 'foo', :Integer])
+      end
+    end
+
+    context 'callable' do
+      let(:fn) do
+        Class.new {
+          def call(input)
+            Integer(input)
+          end
+        }.new
+      end
+
+      specify do
+        expect(function.to_ast).to eql([:callable, fn])
+      end
+    end
+
+    context 'globally accessible receiver' do
+      let(:fn) { Kernel.method(:Integer) }
+
+      specify do
+        expect(function.to_ast).to eql([:method, Kernel, :Integer])
+      end
+    end
+  end
 end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Dry::Types, '#to_ast' do
 
     specify do
       expect(type.to_ast).
-        to eql([:constructor, [[:nominal, [String, {}]], "fn_#{fn.object_id}", key: :value]])
+        to eql([:constructor, [[:nominal, [String, {}]], [:method, Kernel, :String], key: :value]])
     end
   end
 


### PR DESCRIPTION
Now AST can be serialzied and deserialized if it uses only globally accessible constructor functions. This is a robust requirement.