### PR TITLE
Split call into call_safe and call_unsafe

### DIFF
--- a/lib/dry/types/array/member.rb
+++ b/lib/dry/types/array/member.rb
@@ -15,27 +15,31 @@ module Dry
           super
         end
 
-        # @param [Object] input
-        # @return [Array]
-        def call(input, &block)
+        def call_unsafe(input)
           if primitive?(input)
             input.each_with_object([]) do |el, output|
-              coerced =
-                if block_given?
-                  member.(el) { return yield }
-                else
-                  member.(el)
-                end
+              coerced = member.call_unsafe(el)
 
               output << coerced unless Undefined.equal?(coerced)
             end
-          elsif block_given?
-            yield
           else
             super
           end
         end
-        alias_method :[], :call
+
+        # @param [Object] input
+        # @return [Array]
+        def call_safe(input)
+          if primitive?(input)
+            input.each_with_object([]) do |el, output|
+              coerced = member.call_safe(el) { return yield }
+
+              output << coerced unless Undefined.equal?(coerced)
+            end
+          else
+            yield
+          end
+        end
 
         # @param [Array, Object] input
         # @param [#call,nil] block

--- a/lib/dry/types/array/member.rb
+++ b/lib/dry/types/array/member.rb
@@ -15,6 +15,8 @@ module Dry
           super
         end
 
+        # @param [Object] input
+        # @return [Array]
         def call_unsafe(input)
           if primitive?(input)
             input.each_with_object([]) do |el, output|
@@ -29,6 +31,7 @@ module Dry
 
         # @param [Object] input
         # @return [Array]
+        # @api private
         def call_safe(input)
           if primitive?(input)
             input.each_with_object([]) do |el, output|

--- a/lib/dry/types/coercions/params.rb
+++ b/lib/dry/types/coercions/params.rb
@@ -66,7 +66,7 @@ module Dry
         # @param [#to_d, Object] input
         # @return [BigDecimal, nil, Object]
         def self.to_decimal(input, &block)
-          result = to_float(input) do
+          to_float(input) do
             if block_given?
               return yield
             else

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -23,14 +23,6 @@ module Dry
         @rule = options.fetch(:rule)
       end
 
-      def call_safe(input, &block)
-        if rule[input]
-          type.call_safe(input, &block)
-        else
-          yield
-        end
-      end
-
       def call_unsafe(input)
         result = rule.(input)
 
@@ -38,6 +30,14 @@ module Dry
           type.call_unsafe(input)
         else
           raise ConstraintError.new(result, input)
+        end
+      end
+
+      def call_safe(input, &block)
+        if rule[input]
+          type.call_safe(input, &block)
+        else
+          yield
         end
       end
 

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -23,27 +23,23 @@ module Dry
         @rule = options.fetch(:rule)
       end
 
-      # @param [Object] input
-      # @return [Object]
-      # @raise [ConstraintError]
-      def call(input, &block)
-        if block_given?
-          if rule[input]
-            type.(input, &block)
-          else
-            yield
-          end
+      def call_safe(input, &block)
+        if rule[input]
+          type.call_safe(input, &block)
         else
-          result = rule.(input)
-
-          if result.success?
-            type.(input, &block)
-          else
-            raise ConstraintError.new(result, input)
-          end
+          yield
         end
       end
-      alias_method :[], :call
+
+      def call_unsafe(input)
+        result = rule.(input)
+
+        if result.success?
+          type.call_unsafe(input)
+        else
+          raise ConstraintError.new(result, input)
+        end
+      end
 
       # @param [Object] input
       # @param [#call,nil] block

--- a/lib/dry/types/constrained/coercible.rb
+++ b/lib/dry/types/constrained/coercible.rb
@@ -4,16 +4,6 @@ module Dry
   module Types
     class Constrained
       class Coercible < Constrained
-        def call_safe(input)
-          coerced = type.call_safe(input) { return yield }
-
-          if rule[coerced]
-            coerced
-          else
-            yield(coerced)
-          end
-        end
-
         def call_unsafe(input)
           coerced = type.call_unsafe(input)
           result = rule.(coerced)
@@ -22,6 +12,16 @@ module Dry
             coerced
           else
             raise ConstraintError.new(result, input)
+          end
+        end
+
+        def call_safe(input)
+          coerced = type.call_safe(input) { return yield }
+
+          if rule[coerced]
+            coerced
+          else
+            yield(coerced)
           end
         end
 

--- a/lib/dry/types/constrained/coercible.rb
+++ b/lib/dry/types/constrained/coercible.rb
@@ -4,14 +4,22 @@ module Dry
   module Types
     class Constrained
       class Coercible < Constrained
-        def call(input, &block)
-          coerced = type.(input) { return yield if block_given? }
+        def call_safe(input)
+          coerced = type.call_safe(input) { return yield }
+
+          if rule[coerced]
+            coerced
+          else
+            yield(coerced)
+          end
+        end
+
+        def call_unsafe(input)
+          coerced = type.call_unsafe(input)
           result = rule.(coerced)
 
           if result.success?
             coerced
-          elsif block_given?
-            yield(coerced)
           else
             raise ConstraintError.new(result, input)
           end

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -49,17 +49,14 @@ module Dry
         type.default?
       end
 
-      # @param [Object] input
-      # @return [Object]
-      def call(input, &block)
-        if block_given?
-          coerced = fn.(input) { return yield }
-          type.(coerced) { |output = coerced| yield(output) }
-        else
-          type.(fn.(input))
-        end
+      def call_safe(input)
+        coerced = fn.(input) { return yield }
+        type.call_safe(coerced) { |output = coerced| yield(output) }
       end
-      alias_method :[], :call
+
+      def call_unsafe(input)
+        type.call_unsafe(fn.(input))
+      end
 
       # @param [Object] input
       # @param [#call,nil] block

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -64,6 +64,14 @@ module Dry
         value.equal?(Undefined) || super
       end
 
+      def call_unsafe(input = Undefined)
+        if input.equal?(Undefined)
+          evaluate
+        else
+          Undefined.default(type.call_unsafe(input)) { evaluate }
+        end
+      end
+
       # @param [Object] input
       # @return [Object] value passed through {#type} or {#default} value
       def call_safe(input = Undefined, &block)
@@ -71,14 +79,6 @@ module Dry
           evaluate
         else
           Undefined.default(type.call_safe(input, &block)) { evaluate }
-        end
-      end
-
-      def call_unsafe(input = Undefined)
-        if input.equal?(Undefined)
-          evaluate
-        else
-          Undefined.default(type.call_unsafe(input)) { evaluate }
         end
       end
 

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -66,14 +66,21 @@ module Dry
 
       # @param [Object] input
       # @return [Object] value passed through {#type} or {#default} value
-      def call(input = Undefined, &block)
+      def call_safe(input = Undefined, &block)
         if input.equal?(Undefined)
           evaluate
         else
-          Undefined.default(type.(input, &block)) { evaluate }
+          Undefined.default(type.call_safe(input, &block)) { evaluate }
         end
       end
-      alias_method :[], :call
+
+      def call_unsafe(input = Undefined)
+        if input.equal?(Undefined)
+          evaluate
+        else
+          Undefined.default(type.call_unsafe(input)) { evaluate }
+        end
+      end
 
       private
 

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -29,12 +29,13 @@ module Dry
         freeze
       end
 
-      # @param [Object] input
-      # @return [Object]
-      def call(input = Undefined, &block)
-        type.(map_value(input), &block)
+      def call_safe(input, &block)
+        type.call_safe(map_value(input), &block)
       end
-      alias_method :[], :call
+
+      def call_unsafe(input)
+        type.call_unsafe(map_value(input))
+      end
 
       # @param [Object] input
       # @yieldparam [Failure] failure

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -14,17 +14,6 @@ module Dry
 
       # @param [Dry::Monads::Maybe, Object] input
       # @return [Dry::Monads::Maybe]
-      def call_safe(input = Undefined, &block)
-        case input
-        when Dry::Monads::Maybe
-          input
-        when Undefined
-          None()
-        else
-          Maybe(type.call_safe(input, &block))
-        end
-      end
-
       def call_unsafe(input = Undefined)
         case input
         when Dry::Monads::Maybe
@@ -33,6 +22,19 @@ module Dry
           None()
         else
           Maybe(type.call_unsafe(input))
+        end
+      end
+
+      # @param [Dry::Monads::Maybe, Object] input
+      # @return [Dry::Monads::Maybe]
+      def call_safe(input = Undefined, &block)
+        case input
+        when Dry::Monads::Maybe
+          input
+        when Undefined
+          None()
+        else
+          Maybe(type.call_safe(input, &block))
         end
       end
 

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -14,17 +14,27 @@ module Dry
 
       # @param [Dry::Monads::Maybe, Object] input
       # @return [Dry::Monads::Maybe]
-      def call(input = Undefined, &block)
+      def call_safe(input = Undefined, &block)
         case input
         when Dry::Monads::Maybe
           input
         when Undefined
           None()
         else
-          Maybe(type.(input, &block))
+          Maybe(type.call_safe(input, &block))
         end
       end
-      alias_method :[], :call
+
+      def call_unsafe(input = Undefined)
+        case input
+        when Dry::Monads::Maybe
+          input
+        when Undefined
+          None()
+        else
+          Maybe(type.call_unsafe(input))
+        end
+      end
 
       # @param [Object] input
       # @return [Result::Success]

--- a/lib/dry/types/lax.rb
+++ b/lib/dry/types/lax.rb
@@ -20,6 +20,8 @@ module Dry
         type.(input) { |output = input| output }
       end
       alias_method :[], :call
+      alias_method :call_safe, :call
+      alias_method :call_unsafe, :call
 
       # @param [Object] input
       # @param [#call,nil] block

--- a/lib/dry/types/map.rb
+++ b/lib/dry/types/map.rb
@@ -34,7 +34,7 @@ module Dry
       # @param [Hash] hash
       # @return [Hash]
       def call_safe(hash)
-        try(hash) { |failure| return yield }.input
+        try(hash) { return yield }.input
       end
 
       # @param [Hash] hash

--- a/lib/dry/types/map.rb
+++ b/lib/dry/types/map.rb
@@ -25,16 +25,15 @@ module Dry
 
       # @param [Hash] hash
       # @return [Hash]
-      def call(hash, &_block)
+      def call_safe(hash)
+        try(hash) { |failure| return yield }.input
+      end
+
+      def call_unsafe(hash)
         try(hash) { |failure|
-          if block_given?
-            return yield
-          else
-            raise MapError, failure.error.message
-          end
+          raise MapError, failure.error.message
         }.input
       end
-      alias_method :[], :call
 
       # @param [Hash] hash
       # @return [Result]

--- a/lib/dry/types/map.rb
+++ b/lib/dry/types/map.rb
@@ -25,14 +25,16 @@ module Dry
 
       # @param [Hash] hash
       # @return [Hash]
-      def call_safe(hash)
-        try(hash) { |failure| return yield }.input
-      end
-
       def call_unsafe(hash)
         try(hash) { |failure|
           raise MapError, failure.error.message
         }.input
+      end
+
+      # @param [Hash] hash
+      # @return [Hash]
+      def call_safe(hash)
+        try(hash) { |failure| return yield }.input
       end
 
       # @param [Hash] hash

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -59,10 +59,13 @@ module Dry
 
       # @param [BasicObject] input
       # @return [BasicObject]
-      def call(input)
+      def call_safe(input)
         input
       end
-      alias_method :[], :call
+
+      def call_unsafe(input)
+        input
+      end
 
       # @param [Object] input
       # @param [#call,nil] block

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -59,11 +59,13 @@ module Dry
 
       # @param [BasicObject] input
       # @return [BasicObject]
-      def call_safe(input)
+      def call_unsafe(input)
         input
       end
 
-      def call_unsafe(input)
+      # @param [BasicObject] input
+      # @return [BasicObject]
+      def call_safe(input)
         input
       end
 

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -36,7 +36,7 @@ module Dry
           if type.is_a?(Type)
             return yield type.inspect
           else
-            raise ArgumentError, "Do not know how to print #{ type.class }"
+            raise ArgumentError, "Do not know how to print #{type.class}"
           end
         end
         send(print_with, type, &block)

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -50,12 +50,14 @@ module Dry
 
       # @param [Hash] hash
       # @return [Hash{Symbol => Object}]
-      def call_safe(hash, options = EMPTY_HASH)
-        resolve_safe(coerce(hash) { return yield }, options) { return yield }
-      end
-
       def call_unsafe(hash, options = EMPTY_HASH)
         resolve_unsafe(coerce(hash), options)
+      end
+
+      # @param [Hash] hash
+      # @return [Hash{Symbol => Object}]
+      def call_safe(hash, options = EMPTY_HASH)
+        resolve_safe(coerce(hash) { return yield }, options) { return yield }
       end
 
       # @param [Hash] hash

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -51,33 +51,11 @@ module Dry
       # @param [Hash] hash
       # @return [Hash{Symbol => Object}]
       def call_safe(hash, options = EMPTY_HASH)
-        input = coerce(hash) { return yield }
-
-        catch(:schema_error) do
-          return resolve(input, options) do |key, value|
-            key.call_safe(value) { return yield }
-          end
-        end
-
-        yield
+        resolve_safe(coerce(hash) { return yield }, options) { return yield }
       end
 
       def call_unsafe(hash, options = EMPTY_HASH)
-        input = coerce(hash)
-
-        error = catch(:schema_error) do
-          return resolve(input, options) do |key, value|
-            begin
-              key.call_unsafe(value)
-            rescue ConstraintError => error
-              raise SchemaError.new(key.name, value, error.result)
-            rescue CoercionError => error
-              raise SchemaError.new(key.name, value, error.message)
-            end
-          end
-        end
-
-        raise error
+        resolve_unsafe(coerce(hash), options)
       end
 
       # @param [Hash] hash
@@ -97,19 +75,30 @@ module Dry
       def try(input)
         if primitive?(input)
           success = true
-          output  = {}
+          output = {}
+          result = {}
 
-          result = catch(:schema_error) do
-            resolve(input) do |key, value|
-              key_result = key.try(value)
+          input.each do |key, value|
+            k = @transform_key.(key)
+            type = @name_key_map[k]
+
+            if type
+              key_result = type.try(value)
+              result[k] = key_result
+              output[k] = key_result.input
               success &&= key_result.success?
-              output[key.name] = key_result.input
-
-              key_result
+            elsif strict?
+              success = false
             end
           end
 
-          success &&= primitive?(result)
+          if output.size < keys.size
+            resolve_missing_keys(output, options) do
+              success = false
+            end
+          end
+
+          success &&= primitive?(output)
 
           if success
             failure = nil
@@ -260,16 +249,44 @@ module Dry
           values
       end
 
-      def resolve(hash, options = EMPTY_HASH, &block)
+      def resolve_unsafe(hash, options = EMPTY_HASH)
         result = {}
 
         hash.each do |key, value|
-          k = transform_key.(key)
+          k = @transform_key.(key)
+          type = @name_key_map[k]
 
-          if name_key_map.key?(k)
-            result[k] = yield(name_key_map[k], value)
+          if type
+            begin
+              result[k] = type.call_unsafe(value)
+            rescue ConstraintError => error
+              raise SchemaError.new(type.name, value, error.result)
+            rescue CoercionError => error
+              raise SchemaError.new(type.name, value, error.message)
+            end
           elsif strict?
-            throw(:schema_error, unexpected_keys(hash.keys))
+            raise unexpected_keys(hash.keys)
+          end
+        end
+
+        if result.size < keys.size
+          resolve_missing_keys(result, options)
+        end
+
+        result
+      end
+
+      def resolve_safe(hash, options = EMPTY_HASH, &block)
+        result = {}
+
+        hash.each do |key, value|
+          k = @transform_key.(key)
+          type = @name_key_map[k]
+
+          if type
+            result[k] = type.call_safe(value, &block)
+          elsif strict?
+            yield
           end
         end
 
@@ -288,9 +305,13 @@ module Dry
           next if result.key?(key.name)
 
           if key.default? && resolve_defaults
-            result[key.name] = yield(key, Undefined)
+            result[key.name] = key.call_unsafe(Undefined)
           elsif key.required? && !skip_missing
-            throw(:schema_error, missing_key(key.name))
+            if block_given?
+              return yield
+            else
+              raise missing_key(key.name)
+            end
           end
         end
       end

--- a/lib/dry/types/schema/key.rb
+++ b/lib/dry/types/schema/key.rb
@@ -30,9 +30,12 @@ module Dry
           @name = name
         end
 
-        # @see Dry::Types::Nominal#call
-        def call(input, &block)
-          type.(input, &block)
+        def call_safe(input, &block)
+          type.call_safe(input, &block)
+        end
+
+        def call_unsafe(input)
+          type.call_unsafe(input)
         end
 
         # @see Dry::Types::Nominal#try

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -60,10 +60,15 @@ module Dry
 
       # @param [Object] input
       # @return [Object]
-      def call(input, &block)
-        left.(input) { right.(input, &block) }
+      def call_safe(input, &block)
+        left.call_safe(input) { right.call_safe(input, &block) }
       end
-      alias_method :[], :call
+
+      # @param [Object] input
+      # @return [Object]
+      def call_unsafe(input, &block)
+        left.call_safe(input) { right.call_unsafe(input) }
+      end
 
       def try(input)
         left.try(input) do

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -60,7 +60,7 @@ module Dry
 
       # @param [Object] input
       # @return [Object]
-      def call_unsafe(input, &block)
+      def call_unsafe(input)
         left.call_safe(input) { right.call_unsafe(input) }
       end
 

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -60,14 +60,14 @@ module Dry
 
       # @param [Object] input
       # @return [Object]
-      def call_safe(input, &block)
-        left.call_safe(input) { right.call_safe(input, &block) }
+      def call_unsafe(input, &block)
+        left.call_safe(input) { right.call_unsafe(input) }
       end
 
       # @param [Object] input
       # @return [Object]
-      def call_unsafe(input, &block)
-        left.call_safe(input) { right.call_unsafe(input) }
+      def call_safe(input, &block)
+        left.call_safe(input) { right.call_safe(input, &block) }
       end
 
       def try(input)

--- a/lib/dry/types/type.rb
+++ b/lib/dry/types/type.rb
@@ -10,10 +10,19 @@ module Dry
       deprecate(:safe, :lax)
 
       def valid?(input = Undefined)
-        self.(input) { return false }
+        self.call_safe(input) { return false }
         true
       end
       alias_method :===, :valid?
+
+      def call(input = Undefined, &block)
+        if block_given?
+          call_safe(input, &block)
+        else
+          call_unsafe(input)
+        end
+      end
+      alias_method :[], :call
     end
   end
 end

--- a/lib/dry/types/type.rb
+++ b/lib/dry/types/type.rb
@@ -10,7 +10,7 @@ module Dry
       deprecate(:safe, :lax)
 
       def valid?(input = Undefined)
-        self.call_safe(input) { return false }
+        call_safe(input) { return false }
         true
       end
       alias_method :===, :valid?

--- a/spec/dry/types/constrained_spec.rb
+++ b/spec/dry/types/constrained_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Dry::Types::Constrained do
 
     it 'fails when coercion fails' do
       expect { type['foo'] }.to raise_error(
-        Dry::Types::ConstraintError, /foo/
+        Dry::Types::CoercionError, /can't convert String into Hash/
       )
     end
 

--- a/spec/dry/types/constructor/function_spec.rb
+++ b/spec/dry/types/constructor/function_spec.rb
@@ -17,32 +17,24 @@ RSpec.describe Dry::Types::Constructor::Function do
     context 'proc' do
       include_examples 'well-behaving coercion function' do
         subject(:fun) { described_class[proc { |value| Integer(value) }] }
-
-        specify { expect(fun).to be_wrapped }
       end
     end
 
     context 'lambda' do
       include_examples 'well-behaving coercion function' do
         subject(:fun) { described_class[lambda { |value| Integer(value) }] }
-
-        specify { expect(fun).to be_wrapped }
       end
     end
 
     context 'method' do
       include_examples 'well-behaving coercion function' do
         subject(:fun) { described_class[Kernel.method(:Integer)] }
-
-        specify { expect(fun).to be_wrapped }
       end
     end
 
     context 'private method' do
       include_examples 'well-behaving coercion function' do
         subject(:fun) { described_class[1.method(:Integer)] }
-
-        specify { expect(fun).to be_wrapped }
       end
     end
 
@@ -59,8 +51,6 @@ RSpec.describe Dry::Types::Constructor::Function do
 
           described_class[obj.method(:coerce)]
         end
-
-        specify { expect(fun).not_to be_wrapped }
       end
     end
 
@@ -75,8 +65,6 @@ RSpec.describe Dry::Types::Constructor::Function do
 
           described_class[fn]
         end
-
-        specify { expect(fun).to be_wrapped }
       end
     end
 
@@ -93,8 +81,6 @@ RSpec.describe Dry::Types::Constructor::Function do
 
           described_class[fn]
         end
-
-        specify { expect(fun).not_to be_wrapped }
       end
     end
   end


### PR DESCRIPTION
The idea is to choose the execution path in the top-level type. This PR also eliminates super calls in functions of constructor types, makes them faster for free.

```
$ bundle exec ruby benchmarks/schema_valid_vs_invalid.rb 
Warming up --------------------------------------
         valid input    84.216k i/100ms
       invalid input    85.912k i/100ms
Calculating -------------------------------------
         valid input      1.088M (± 3.7%) i/s -      5.474M in   5.037302s
       invalid input      1.098M (± 1.4%) i/s -      5.498M in   5.006690s

Comparison:
       invalid input:  1098412.8 i/s
         valid input:  1088334.7 i/s - same-ish: difference falls within error
```