### PR TITLE
Push meta down to decorated type

### DIFF
--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -106,8 +106,8 @@ module Dry
       end
 
       def visit_map(node)
-        key_type, value_type = node
-        registry['nominal.hash'].map(visit(key_type), visit(value_type))
+        key_type, value_type, meta = node
+        registry['nominal.hash'].map(visit(key_type), visit(value_type)).meta(meta)
       end
 
       def visit_any(meta)

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -19,30 +19,29 @@ module Dry
 
       def visit(node)
         type, body = node
-        send(:"visit_#{ type }", body)
+        send(:"visit_#{type}", body)
       end
 
       def visit_constrained(node)
-        nominal, rule, meta = node
+        nominal, rule = node
         type = visit(nominal)
-        type.constrained_type.new(type, rule: visit_rule(rule)).meta(meta)
+        type.constrained_type.new(type, rule: visit_rule(rule))
       end
 
       def visit_constructor(node)
-        nominal, fn, meta = node
+        nominal, fn = node
         primitive = visit(nominal)
-        primitive.constructor(compile_fn(fn)).meta(meta)
+        primitive.constructor(compile_fn(fn))
       end
 
       def visit_lax(node)
-        ast, meta = node
-        Types::Lax.new(visit(ast), meta: meta)
+        Types::Lax.new(visit(node))
       end
       deprecate(:visit_safe, :visit_lax)
 
       def visit_nominal(node)
         type, meta = node
-        nominal_name = "nominal.#{ Types.identifier(type) }"
+        nominal_name = "nominal.#{Types.identifier(type)}"
 
         if registry.registered?(nominal_name)
           registry[nominal_name].meta(meta)
@@ -102,13 +101,13 @@ module Dry
       end
 
       def visit_enum(node)
-        type, mapping, meta = node
-        Enum.new(visit(type), mapping: mapping, meta: meta)
+        type, mapping = node
+        Enum.new(visit(type), mapping: mapping)
       end
 
       def visit_map(node)
-        key_type, value_type, meta = node
-        registry['nominal.hash'].map(visit(key_type), visit(value_type)).meta(meta)
+        key_type, value_type = node
+        registry['nominal.hash'].map(visit(key_type), visit(value_type))
       end
 
       def visit_any(meta)

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -11,7 +11,7 @@ module Dry
       include Decorator
       include Builder
       include Printable
-      include Dry::Equalizer(:type, :options, :rule, :meta, inspect: false)
+      include Dry::Equalizer(:type, :rule, inspect: false)
 
       # @return [Dry::Logic::Rule]
       attr_reader :rule
@@ -86,9 +86,7 @@ module Dry
       #
       # @see Nominal#to_ast
       def to_ast(meta: true)
-        [:constrained, [type.to_ast(meta: meta),
-                        rule.to_ast,
-                        meta ? self.meta : EMPTY_HASH]]
+        [:constrained, [type.to_ast(meta: meta), rule.to_ast]]
       end
 
       private

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -6,7 +6,9 @@ require 'dry/types/constructor/function'
 module Dry
   module Types
     class Constructor < Nominal
-      include Dry::Equalizer(:type, :options, :meta, inspect: false)
+      include Dry::Equalizer(:type, :options, inspect: false)
+
+      private :meta
 
       # @return [#call]
       attr_reader :fn
@@ -93,9 +95,7 @@ module Dry
       #
       # @see Nominal#to_ast
       def to_ast(meta: true)
-        [:constructor, [type.to_ast(meta: meta),
-                        fn.to_ast,
-                        meta ? self.meta : EMPTY_HASH]]
+        [:constructor, [type.to_ast(meta: meta), fn.to_ast]]
       end
 
       # @api public

--- a/lib/dry/types/decorator.rb
+++ b/lib/dry/types/decorator.rb
@@ -46,13 +46,6 @@ module Dry
         super || type.respond_to?(meth)
       end
 
-      # Replace the underlying type
-      # @param [Dry::Types::Type] type
-      # @return [Dry::Types::Schema::Key]
-      def new(type)
-        self.class.new(type, *@__args__[1..-1], **@options)
-      end
-
       private
 
       # @param [Object] response
@@ -81,7 +74,7 @@ module Dry
 
       # Replace underlying type
       def __new__(type)
-        self.class.new(type, options)
+        self.class.new(type, *@__args__[1..-1], **@options)
       end
     end
   end

--- a/lib/dry/types/decorator.rb
+++ b/lib/dry/types/decorator.rb
@@ -46,6 +46,13 @@ module Dry
         super || type.respond_to?(meth)
       end
 
+      # Replace the underlying type
+      # @param [Dry::Types::Type] type
+      # @return [Dry::Types::Schema::Key]
+      def new(type)
+        self.class.new(type, *@__args__[1..-1], **@options)
+      end
+
       private
 
       # @param [Object] response

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -5,14 +5,8 @@ require 'dry/types/decorator'
 module Dry
   module Types
     class Default
-      include Type
-      include Decorator
-      include Builder
-      include Printable
-      include Dry::Equalizer(:type, :options, :value, inspect: false)
-
       class Callable < Default
-        include Dry::Equalizer(:type, :options, inspect: false)
+        include Dry::Equalizer(:type, inspect: false)
 
         # Evaluates given callable
         # @return [Object]
@@ -20,6 +14,12 @@ module Dry
           value.call(type)
         end
       end
+
+      include Type
+      include Decorator
+      include Builder
+      include Printable
+      include Dry::Equalizer(:type, :value, inspect: false)
 
       # @return [Object]
       attr_reader :value

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -6,7 +6,7 @@ module Dry
   module Types
     class Enum
       include Type
-      include Dry::Equalizer(:type, :options, :mapping, inspect: false)
+      include Dry::Equalizer(:type, :mapping, inspect: false)
       include Decorator
 
       # @return [Array]
@@ -58,9 +58,7 @@ module Dry
       #
       # @see Nominal#to_ast
       def to_ast(meta: true)
-        [:enum, [type.to_ast(meta: meta),
-                 mapping,
-                 meta ? self.meta : EMPTY_HASH]]
+        [:enum, [type.to_ast(meta: meta), mapping]]
       end
 
       # @return [String]

--- a/lib/dry/types/lax.rb
+++ b/lib/dry/types/lax.rb
@@ -12,7 +12,7 @@ module Dry
       include Printable
       include Dry::Equalizer(:type, inspect: false)
 
-      private :options, :meta, :constructor
+      private :options, :constructor
 
       # @param [Object] input
       # @return [Object]
@@ -39,7 +39,7 @@ module Dry
       #
       # @see Nominal#to_ast
       def to_ast(meta: true)
-        [:lax, [type.to_ast(meta: meta), EMPTY_HASH]]
+        [:lax, type.to_ast(meta: meta)]
       end
 
       # @api public

--- a/lib/dry/types/map.rb
+++ b/lib/dry/types/map.rb
@@ -5,7 +5,6 @@ module Dry
     class Map < Nominal
       def initialize(_primitive, key_type: Types['any'], value_type: Types['any'], meta: EMPTY_HASH)
         super(_primitive, key_type: key_type, value_type: value_type, meta: meta)
-        validate_options!
       end
 
       # @return [Type]
@@ -49,7 +48,9 @@ module Dry
       # @return [Array] An AST representation
       def to_ast(meta: true)
         [:map,
-         [key_type.to_ast(meta: true), value_type.to_ast(meta: true)]]
+         [key_type.to_ast(meta: true),
+          value_type.to_ast(meta: true),
+          meta ? self.meta : EMPTY_HASH]]
       end
 
       # @return [Boolean]
@@ -84,14 +85,6 @@ module Dry
         return success(output) if failures.empty?
 
         failure(input, MultipleError.new(failures))
-      end
-
-      def validate_options!
-        %i(key_type value_type).each do |opt|
-          type = send(opt)
-          next if type.is_a?(Type)
-          raise MapError, ":#{opt} must be a #{Type}, got: #{type.inspect}"
-        end
       end
     end
   end

--- a/lib/dry/types/map.rb
+++ b/lib/dry/types/map.rb
@@ -49,8 +49,7 @@ module Dry
       # @return [Array] An AST representation
       def to_ast(meta: true)
         [:map,
-         [key_type.to_ast(meta: true), value_type.to_ast(meta: true),
-          meta ? self.meta : EMPTY_HASH]]
+         [key_type.to_ast(meta: true), value_type.to_ast(meta: true)]]
       end
 
       # @return [Boolean]

--- a/lib/dry/types/meta.rb
+++ b/lib/dry/types/meta.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Dry
+  module Types
+    module Meta
+      def initialize(*args, meta: EMPTY_HASH, **options)
+        super(*args, **options)
+        @meta = meta.freeze
+      end
+
+      # @param [Hash] new_options
+      # @return [Type]
+      def with(**options)
+        super(meta: @meta, **options)
+      end
+
+      # @overload meta
+      #   @return [Hash] metadata associated with type
+      #
+      # @overload meta(data)
+      #   @param [Hash] new metadata to merge into existing metadata
+      #   @return [Type] new type with added metadata
+      def meta(data = nil)
+        if !data
+          @meta
+        elsif data.empty?
+          self
+        else
+          with(meta: @meta.merge(data))
+        end
+      end
+
+      # Resets meta
+      # @return [Dry::Types::Type]
+      def pristine
+        with(meta: EMPTY_HASH)
+      end
+    end
+  end
+end

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -4,12 +4,14 @@ require 'dry/core/deprecations'
 require 'dry/types/builder'
 require 'dry/types/result'
 require 'dry/types/options'
+require 'dry/types/meta'
 
 module Dry
   module Types
     class Nominal
       include Type
       include Options
+      include Meta
       include Builder
       include Printable
       include Dry::Equalizer(:primitive, :options, :meta, inspect: false)

--- a/lib/dry/types/options.rb
+++ b/lib/dry/types/options.rb
@@ -7,38 +7,15 @@ module Dry
       attr_reader :options
 
       # @see Nominal#initialize
-      def initialize(*args, meta: EMPTY_HASH, **options)
+      def initialize(*args, **options)
         @__args__ = args.freeze
         @options = options.freeze
-        @meta = meta.freeze
       end
 
       # @param [Hash] new_options
       # @return [Type]
       def with(**new_options)
-        self.class.new(*@__args__, **options, meta: @meta, **new_options)
-      end
-
-      # @overload meta
-      #   @return [Hash] metadata associated with type
-      #
-      # @overload meta(data)
-      #   @param [Hash] new metadata to merge into existing metadata
-      #   @return [Type] new type with added metadata
-      def meta(data = nil)
-        if !data
-          @meta
-        elsif data.empty?
-          self
-        else
-          with(meta: @meta.merge(data))
-        end
-      end
-
-      # Resets meta
-      # @return [Dry::Types::Type]
-      def pristine
-        with(meta: EMPTY_HASH)
+        self.class.new(*@__args__, **options, **new_options)
       end
     end
   end

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -104,6 +104,7 @@ module Dry
         keys = options.delete(:keys)
 
         visit_options(options, schema.meta) do |opts|
+          opts = "#{opts[1..-1]} " unless opts.empty?
           schema_parameters = "#{key_fn_str}#{type_fn_str}#{strict_str}#{opts}"
 
           header = "Schema<#{schema_parameters}keys={"

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -62,7 +62,7 @@ module Dry
             options = constructor.options.dup
             options.delete(:fn)
 
-            visit_options(options, constructor.meta) do |opts|
+            visit_options(options) do |opts|
               yield "Constructor<#{type} fn=#{fn}#{opts}>"
             end
           end
@@ -74,7 +74,7 @@ module Dry
           options = constrained.options.dup
           rule = options.delete(:rule)
 
-          visit_options(options, constrained.meta) do |opts|
+          visit_options(options) do |opts|
             yield "Constrained<#{type} rule=[#{rule}]>"
           end
         end
@@ -125,7 +125,7 @@ module Dry
             options.delete(:key_type)
             options.delete(:value_type)
 
-            visit_options(options, map.meta) do |opts|
+            visit_options(options) do |opts|
               yield "Map<#{ key } => #{ value }>"
             end
           end
@@ -186,7 +186,7 @@ module Dry
           options = enum.options.dup
           mapping = options.delete(:mapping)
 
-          visit_options(options, enum.meta) do |opts|
+          visit_options(options) do |opts|
             if mapping == enum.inverted_mapping
               values = mapping.values.map(&:inspect).join(", ")
               yield "Enum<#{ type } values={#{ values }}#{ opts }>"
@@ -202,7 +202,7 @@ module Dry
 
       def visit_default(default)
         visit(default.type) do |type|
-          visit_options(default.options, default.meta) do |opts|
+          visit_options(default.options) do |opts|
             if default.is_a?(Default::Callable)
               visit_callable(default.value) do |fn|
                 yield "Default<#{ type } value_fn=#{ fn }#{ opts }>"
@@ -280,7 +280,7 @@ module Dry
         end
       end
 
-      def visit_options(options, meta)
+      def visit_options(options, meta = EMPTY_HASH)
         if options.empty? && meta.empty?
           yield ""
         else

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -134,11 +134,7 @@ module Dry
 
         [
           :schema,
-          [
-            keys.map { |key| key.to_ast(meta: meta) },
-            opts,
-            meta ? self.meta : EMPTY_HASH
-          ]
+          [keys.map { |key| key.to_ast(meta: meta) }, opts]
         ]
       end
 

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -134,7 +134,9 @@ module Dry
 
         [
           :schema,
-          [keys.map { |key| key.to_ast(meta: meta) }, opts]
+          [keys.map { |key| key.to_ast(meta: meta) },
+            opts,
+            meta ? self.meta : EMPTY_HASH]
         ]
       end
 

--- a/lib/dry/types/schema/key.rb
+++ b/lib/dry/types/schema/key.rb
@@ -85,13 +85,6 @@ module Dry
           new(type.default(input, &block))
         end
 
-        # Replace the underlying type
-        # @param [Dry::Types::Type] type
-        # @return [Dry::Types::Schema::Key]
-        def new(type)
-          self.class.new(type, name, options)
-        end
-
         # @see Dry::Types::Lax
         # @return [Dry::Types::Schema::Key]
         def lax
@@ -110,24 +103,6 @@ module Dry
               type.to_ast(meta: meta)
             ]
           ]
-        end
-
-        # Get/set type metadata. The Key type doesn't have
-        # its out meta, it delegates these calls to the underlying
-        # type.
-        #
-        # @overload meta
-        #   @return [Hash] metadata associated with type
-        #
-        # @overload meta(data)
-        #   @param [Hash] new metadata to merge into existing metadata
-        #   @return [Type] new type with added metadata
-        def meta(data = nil)
-          if data.nil?
-            type.meta
-          else
-            new(type.meta(data))
-          end
         end
       end
     end

--- a/lib/dry/types/schema/key.rb
+++ b/lib/dry/types/schema/key.rb
@@ -75,20 +75,10 @@ module Dry
           required(false)
         end
 
-        # Construct a default type. Default values are
-        # evaluated/applied when key is absent in schema
-        # input.
-        #
-        # @see Dry::Types::Default
-        # @return [Dry::Types::Schema::Key]
-        def default(input = Undefined, &block)
-          new(type.default(input, &block))
-        end
-
         # @see Dry::Types::Lax
         # @return [Dry::Types::Schema::Key]
         def lax
-          new(type.lax).required(false)
+          super.required(false)
         end
 
         # Dump to internal AST representation
@@ -103,6 +93,12 @@ module Dry
               type.to_ast(meta: meta)
             ]
           ]
+        end
+
+        private
+
+        def decorate?(response)
+          response.is_a?(Type)
         end
       end
     end

--- a/lib/dry/types/spec/types.rb
+++ b/lib/dry/types/spec/types.rb
@@ -71,7 +71,7 @@ RSpec.shared_examples_for 'Dry::Types::Nominal#meta' do
       expect(type.meta).to be_a ::Hash
       expect(type.meta).to be_frozen
       expect(type.meta).not_to have_key :immutable_test
-      derived = type.with(meta: {immutable_test: 1})
+      derived = type.meta(immutable_test: 1)
       expect(derived.meta).to be_frozen
       expect(derived.meta).to eql({immutable_test: 1})
       expect(type.meta).not_to have_key :immutable_test

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/types/options'
+require 'dry/types/meta'
 
 module Dry
   module Types
@@ -8,6 +9,7 @@ module Dry
       include Type
       include Builder
       include Options
+      include Meta
       include Printable
       include Dry::Equalizer(:left, :right, :options, :meta, inspect: false)
 

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -108,6 +108,16 @@ module Dry
         left.primitive?(value) || right.primitive?(value)
       end
 
+      def meta(data = nil)
+        if data.nil?
+          optional? ? right.meta : super
+        elsif optional?
+          self.class.new(left, right.meta(data), options)
+        else
+          super
+        end
+      end
+
       # @api public
       #
       # @see Nominal#to_ast

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -324,12 +324,10 @@ RSpec.describe Dry::Types::Compiler, '#call' do
                :map, [
                   [:constrained,
                    [[:nominal, [String, {}]],
-                    [:predicate, [:type?, [[:type, String], [:input, Undefined]]]],
-                    {}]],
+                    [:predicate, [:type?, [[:type, String], [:input, Undefined]]]]]],
                   [:constrained,
                    [[:nominal, [Integer, {}]],
-                    [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]],
-                    {}]],
+                    [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]]]],
                   abc: 123, foo: 'bar'
                 ]
               ])

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -259,4 +259,13 @@ RSpec.describe Dry::Types::Builder, '#default' do
       end
     end
   end
+
+  describe '#meta' do
+    subject(:type) { Dry::Types['nominal.string'].meta(foo: :bar).default('foo'.freeze) }
+
+    it 'adds uses meta from the decorated type' do
+      expect(type.meta).to eql(foo: :bar)
+      expect(type.meta(bar: :baz).meta).to eql(foo: :bar, bar: :baz)
+    end
+  end
 end

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Dry::Types::Builder, '#default' do
   end
 
   describe '#with' do
-    subject(:type) { Dry::Types['nominal.time'].default { Time.now }.with(meta: { foo: :bar }) }
+    subject(:type) { Dry::Types['nominal.time'].default { Time.now }.meta(foo: :bar) }
 
     it_behaves_like Dry::Types::Nominal
 

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Dry::Types::Enum do
   end
 
   describe '#with' do
-    subject(:enum_with_meta) { Dry::Types['nominal.integer'].enum(4, 5, 6).with(meta: { foo: :bar }) }
+    subject(:enum_with_meta) { Dry::Types['nominal.integer'].enum(4, 5, 6).meta(foo: :bar) }
 
     it_behaves_like Dry::Types::Nominal do
       let(:type) { enum_with_meta }

--- a/spec/dry/types/map_spec.rb
+++ b/spec/dry/types/map_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe Dry::Types::Map do
       Dry::Types::Map.new(
         ::Hash,
         key_type:   Dry::Types['strict.integer'],
-        value_type: Dry::Types['strict.string'],
-        meta:   { a: 1, b: 2, c: 3 }
+        value_type: Dry::Types['strict.string']
       )
     end
 
@@ -77,29 +76,25 @@ RSpec.describe Dry::Types::Map do
         expect(empty_map.with(key_type: Dry::Types['strict.integer'])).to eql keyed_map
         expect(empty_map.with(value_type: Dry::Types['strict.string'])).to eql value_map
         partial = value_map.with(key_type: Dry::Types['strict.integer'])
-        expect(partial).not_to eql complex_map
-        expect(partial.with(meta: {a:1, b:2, c:3})).to eql complex_map
+        expect(partial).to eql complex_map
       end
     end
 
     describe '#to_ast' do
       let(:any_ast) { Dry::Types::Any.to_ast }
       it 'decomposes the map into an ast array' do
-        expect(empty_map.to_ast).to eql [:map, [any_ast, any_ast, {}]]
+        expect(empty_map.to_ast).to eql [:map, [any_ast, any_ast]]
         expect(complex_map.to_ast).
           to eql(
                [:map, [
                   [:constrained, [
                      [:nominal, [Integer, {}]],
-                     [:predicate, [:type?, [[:type, Integer], [:input, Dry::Types::Undefined]]]],
-                     {}
+                     [:predicate, [:type?, [[:type, Integer], [:input, Dry::Types::Undefined]]]]
                    ]],
                   [:constrained, [
                      [:nominal, [String, {}]],
-                     [:predicate, [:type?, [[:type, String], [:input, Dry::Types::Undefined]]]],
-                     {}
-                   ]],
-                  { a:1, b:2, c:3 }
+                     [:predicate, [:type?, [[:type, String], [:input, Dry::Types::Undefined]]]]
+                   ]]
                 ]
                ]
              )

--- a/spec/dry/types/map_spec.rb
+++ b/spec/dry/types/map_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe Dry::Types::Map do
         expect(keyed_map.key_type).to eql Dry::Types['strict.integer']
         expect(complex_map.key_type).to eql Dry::Types['strict.integer']
       end
-
-      it 'must be a Type' do
-        expect {
-          Dry::Types::Map.new(::Hash, key_type: "seven")
-        }.to raise_error(Dry::Types::MapError, /must be a Dry::Types::Type/)
-      end
     end
 
     describe '#value_type' do
@@ -44,12 +38,6 @@ RSpec.describe Dry::Types::Map do
         expect(keyed_map.value_type).to eql Dry::Types['any']
         expect(value_map.value_type).to eql Dry::Types['strict.string']
         expect(complex_map.value_type).to eql Dry::Types['strict.string']
-      end
-
-      it 'must be a Type' do
-        expect {
-          Dry::Types::Map.new(::Hash, value_type: "seven")
-        }.to raise_error(Dry::Types::MapError, /must be a Dry::Types::Type/)
       end
     end
 
@@ -83,7 +71,7 @@ RSpec.describe Dry::Types::Map do
     describe '#to_ast' do
       let(:any_ast) { Dry::Types::Any.to_ast }
       it 'decomposes the map into an ast array' do
-        expect(empty_map.to_ast).to eql [:map, [any_ast, any_ast]]
+        expect(empty_map.to_ast).to eql [:map, [any_ast, any_ast, {}]]
         expect(complex_map.to_ast).
           to eql(
                [:map, [
@@ -94,7 +82,8 @@ RSpec.describe Dry::Types::Map do
                   [:constrained, [
                      [:nominal, [String, {}]],
                      [:predicate, [:type?, [[:type, String], [:input, Dry::Types::Undefined]]]]
-                   ]]
+                   ]],
+                  {}
                 ]
                ]
              )

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -330,8 +330,15 @@ RSpec.describe Dry::Types::Schema do
 
     describe '#schema' do
       it 'extends existing schema' do
-        extended = subject.schema(city: "coercible.string")
-        expect(extended.({**valid_input, city: :London})).to include(city: 'London')
+        extended = subject.schema(city: 'coercible.string')
+        expect(extended.({ **valid_input, city: :London })).to include(city: 'London')
+        expect(extended.key(:city).type).to eql(Dry::Types['coercible.string'])
+      end
+
+      example 'in presence of type transformation' do
+        extended = subject.with_type_transform { |k| k.meta(transformed: true) }.schema(city: 'coercible.string')
+        expect(extended.({ **valid_input, city: :London })).to include(city: 'London')
+        expect(extended.key(:city)).to eql(Dry::Types::Schema::Key.new(Dry::Types['coercible.string'], :city))
       end
     end
 

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -290,4 +290,17 @@ RSpec.describe Dry::Types::Sum do
       expect { type[12345] }.to raise_error(Dry::Types::ConstraintError)
     end
   end
+
+  describe '#meta' do
+    context 'optional types' do
+      let(:meta) { { foo: :bar } }
+
+      subject(:type) { Dry::Types['string'].optional }
+
+      it 'uses meta from the right branch' do
+        expect(type.meta(meta).meta).to eql(meta)
+        expect(type.meta(meta).right.meta).to eql(meta)
+      end
+    end
+  end
 end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Dry::Types, '#to_ast' do
 
     specify do
       expect(type.to_ast).
-        to eql([:constructor, [[:nominal, [String, {}]], [:method, Kernel, :String], key: :value]])
+        to eql([:constructor, [[:nominal, [String, key: :value]], [:method, Kernel, :String]]])
     end
   end
 

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -60,16 +60,14 @@ RSpec.describe Dry::Types, '#to_ast' do
         to eql([:constrained, [
                   [:nominal, [Integer, {}]],
                   [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]],
-                  {}
                ]])
     end
 
     specify 'with meta' do
       expect(type_with_meta.to_ast).
         to eql([:constrained, [
-                  [:nominal, [Integer, {}]],
-                  [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]],
-                  key: :value
+                  [:nominal, [Integer, key: :value]],
+                  [:predicate, [:type?, [[:type, Integer], [:input, Undefined]]]]
                 ]])
     end
   end
@@ -126,7 +124,7 @@ RSpec.describe Dry::Types, '#to_ast' do
                    [
                      :constrained,
                      [
-                       [:nominal, [String, {}]],
+                       [:nominal, [String, key: :value]],
                        [
                          :and,
                          [
@@ -140,12 +138,10 @@ RSpec.describe Dry::Types, '#to_ast' do
                               [[:list, ["draft", "published", "archived"]], [:input, Undefined]]]
                            ]
                          ]
-                       ],
-                       {}
+                       ]
                      ]
                    ],
                    {"draft" => "draft", "published" => "published", "archived" => "archived"},
-                   key: :value
                  ]
                ])
     end


### PR DESCRIPTION
This changes the place where metadata is stored by pushing it down to the decorated type. As far as I can tell this is not a significant change, no regression was found in my application, rom & rom-sql are both green except for two specs. OTOH it adds more reliable and predictable behavior when working with metadata: no matter how you embellish your source type, the meta will be preserved:

Before:
```ruby
[1] pry(main)> Types::String.meta(name: :full_name).constructor(&:to_s).meta
=> {}
```

After:
```ruby
[1] pry(main)> Types::String.meta(name: :full_name).constructor(&:to_s).meta
=> {:name=>:full_name}
```

This immediately solves some issues we found in rom while trying to use default types in relation schemas. Besides it, the new behavior looks more ligical and consistent to me.