### PR TITLE
Adds `.Contract(*methods)` type constructor

### DIFF
--- a/lib/dry/types/builder_methods.rb
+++ b/lib/dry/types/builder_methods.rb
@@ -107,6 +107,22 @@ module Dry
       def Map(key_type, value_type)
         Types['nominal.hash'].map(key_type, value_type)
       end
+
+      # Builds a constrained nominal type accepting any value that
+      # responds to given methods
+      #
+      # @example
+      #   Types::Callable = Types.Contract(:call)
+      #   Types::Contact = Types.Contract(:name, :address)
+      #
+      # @param methods [Array<String, Symbol>] Method names
+      #
+      # @return [Dry::Types::Contrained]
+      def Contract(*methods)
+        methods.reduce(Types['nominal.any']) do |type, method|
+          type.constrained(respond_to: method)
+        end
+      end
     end
   end
 end

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -93,6 +93,13 @@ RSpec.describe Dry::Types::Module do
       end
     end
 
+    describe '.Contract' do
+      it 'builds a constrained nominal type of any responding to methods' do
+        expect(mod.Contract(:new, :method)).
+          to eql(Dry::Types::Any.constrained(respond_to: :new).constrained(respond_to: :method))
+      end
+    end
+
     describe 'JSON' do
       it 'defines json types' do
         expect(mod::JSON::Decimal).to be(Dry::Types['json.decimal'])


### PR DESCRIPTION
This constructs a nominal `Any` with constraints of having given methods
implemented.

Example:

```ruby
Callable = Types::Contract(:call)
Contact = Types::Contract(:name, :address)
```

References #56

**Resources**

[Original
discussion](https://discourse.dry-rb.org/t/support-for-type-classes/759)