### PR TITLE
Postpone release of Types.Contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,9 @@
 
 ## Added
 
-- New builder method `Contract` constructs a type which accepts objects that respond to the given methods (waiting-for-dev)
-  ```ruby
-  Types = Dry.Types()
-  Types::Callable = Types.Contract(:call)
-  Types::Callable.valid?(Object.new) # => false
-  Types::Callable.valid?(proc {})    # => true
-  ```
 - In the case of failure the constructor block can now pass a different value (flash-gordon)
   ```ruby
-  not_empty_string = Types::String.constructor do |value, &failure| 
+  not_empty_string = Types::String.constructor do |value, &failure|
     value.strip.empty? ? failure.(nil) : value.strip
   end
   not_empty_string.('   ') { |v| v } # => nil

--- a/lib/dry/types/builder_methods.rb
+++ b/lib/dry/types/builder_methods.rb
@@ -108,21 +108,21 @@ module Dry
         Types['nominal.hash'].map(key_type, value_type)
       end
 
-      # Builds a constrained nominal type accepting any value that
-      # responds to given methods
-      #
-      # @example
-      #   Types::Callable = Types.Contract(:call)
-      #   Types::Contact = Types.Contract(:name, :address)
-      #
-      # @param methods [Array<String, Symbol>] Method names
-      #
-      # @return [Dry::Types::Contrained]
-      def Contract(*methods)
-        methods.reduce(Types['nominal.any']) do |type, method|
-          type.constrained(respond_to: method)
-        end
-      end
+      # # Builds a constrained nominal type accepting any value that
+      # # responds to given methods
+      # #
+      # # @example
+      # #   Types::Callable = Types.Contract(:call)
+      # #   Types::Contact = Types.Contract(:name, :address)
+      # #
+      # # @param methods [Array<String, Symbol>] Method names
+      # #
+      # # @return [Dry::Types::Contrained]
+      # def Contract(*methods)
+      #   methods.reduce(Types['nominal.any']) do |type, method|
+      #     type.constrained(respond_to: method)
+      #   end
+      # end
     end
   end
 end

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe Dry::Types::Module do
 
     describe '.Contract' do
       it 'builds a constrained nominal type of any responding to methods' do
+        pending 'add support for Contract once dry-schema works nicely with new dry-logic'
         expect(mod.Contract(:new, :method)).
           to eql(Dry::Types::Any.constrained(respond_to: :new).constrained(respond_to: :method))
       end


### PR DESCRIPTION
We cannot yet release a new version of dry-logic because dry-schema will be broken in this case. This commit postpones release of this feature until 1.1.0