### PR TITLE
Add Coercible::Symbol, Params::Symbol & JSON::Symbol

### DIFF
--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -88,6 +88,19 @@ module Dry
         end
       end
 
+      # @param [#to_sym, Object] input
+      #
+      # @return [Symbol, Object]
+      #
+      # @raise CoercionError
+      #
+      # @api public
+      def to_symbol(input, &block)
+        input.to_sym
+      rescue NoMethodError => error
+        CoercionError.handle(error, &block)
+      end
+
       private
 
       # Checks whether String is empty

--- a/lib/dry/types/json.rb
+++ b/lib/dry/types/json.rb
@@ -24,6 +24,10 @@ module Dry
       self['nominal.decimal'].constructor(Coercions::JSON.method(:to_decimal))
     end
 
+    register('json.symbol') do
+      self['nominal.symbol'].constructor(Coercions::JSON.method(:to_symbol))
+    end
+
     register('json.array') { self['array'] }
 
     register('json.hash') { self['hash'] }

--- a/lib/dry/types/params.rb
+++ b/lib/dry/types/params.rb
@@ -51,5 +51,9 @@ module Dry
     register('params.hash') do
       self['nominal.hash'].constructor(Coercions::Params.method(:to_hash))
     end
+
+    register('params.symbol') do
+      self['nominal.symbol'].constructor(Coercions::Params.method(:to_symbol))
+    end
   end
 end

--- a/spec/dry/types/core_spec.rb
+++ b/spec/dry/types/core_spec.rb
@@ -211,4 +211,18 @@ RSpec.describe Dry::Types::Nominal do
       expect(any.meta(name: :age).meta).to eql(name: :age)
     end
   end
+
+  context 'coercible by convention method' do
+    describe 'with Symbol' do
+      let(:coercible_symbol) { Dry::Types["coercible.symbol"] }
+
+      it_behaves_like 'Dry::Types::Nominal without primitive' do
+        let(:type) { coercible_symbol }
+      end
+
+      it 'accepts an object coercible to a symbol' do
+        expect(coercible_symbol['a']).to eql(:a)
+      end
+    end
+  end
 end

--- a/spec/dry/types/types/json_spec.rb
+++ b/spec/dry/types/types/json_spec.rb
@@ -80,4 +80,16 @@ RSpec.describe Dry::Types::Nominal do
       Object.new, 'not-a-hash'
     ]
   end
+
+  describe 'json.symbol' do
+    subject(:type) { Dry::Types['json.symbol'] }
+
+    it_behaves_like 'a constrained type', inputs: [
+      Object.new, 1
+    ]
+
+    it 'coerces to a symbol' do
+      expect(type['a']).to eql(:a)
+    end
+  end
 end

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -207,4 +207,16 @@ RSpec.describe Dry::Types::Nominal do
       expect(type[input]).to eql({})
     end
   end
+
+  describe 'params.symbol' do
+    subject(:type) { Dry::Types['params.symbol'] }
+
+    it_behaves_like 'a constrained type', inputs: [
+      Object.new, 1
+    ]
+
+    it 'coerces to a symbol' do
+      expect(type['a']).to eql(:a)
+    end
+  end
 end


### PR DESCRIPTION
I have kept the distinction between kernel or by convention method coercion in the implementation, so it would be easy to separate them as different families if desired in the future.

Closes #47 