### PR TITLE
Add Array::Constructor

### DIFF
--- a/lib/dry/types/array.rb
+++ b/lib/dry/types/array.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/types/array/member'
+require 'dry/types/array/constructor'
 
 module Dry
   module Types
@@ -23,6 +24,11 @@ module Dry
           end
 
         Array::Member.new(primitive, **options, member: member)
+      end
+
+      # @api private
+      def constructor_type
+        ::Dry::Types::Array::Constructor
       end
     end
   end

--- a/lib/dry/types/array/constructor.rb
+++ b/lib/dry/types/array/constructor.rb
@@ -17,14 +17,14 @@ module Dry
         #
         # @api public
         def lax
-          type.lax.constructor(fn, meta: meta)
+          Lax.new(type.lax.constructor(fn, meta: meta))
         end
 
-        private
-
-        # @api private
-        def composable?(value)
-          super && value.is_a?(Constructor)
+        # @see Dry::Types::Array#of
+        #
+        # @api public
+        def of(member)
+          type.of(member).constructor(fn, meta: meta)
         end
       end
     end

--- a/lib/dry/types/array/constructor.rb
+++ b/lib/dry/types/array/constructor.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'dry/types/constructor'
+
+module Dry
+  module Types
+    # @api public
+    class Array < Nominal
+      # @api private
+      class Constructor < ::Dry::Types::Constructor
+        # @api private
+        def constructor_type
+          ::Dry::Types::Array::Constructor
+        end
+
+        # @return [Lax]
+        #
+        # @api public
+        def lax
+          type.lax.constructor(fn, meta: meta)
+        end
+
+        private
+
+        # @api private
+        def composable?(value)
+          super && value.is_a?(Constructor)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/types/array/member.rb
+++ b/lib/dry/types/array/member.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dry/types/array/constructor'
+
 module Dry
   module Types
     class Array < Nominal
@@ -110,6 +112,11 @@ module Dry
           else
             [:array, [member, meta ? self.meta : EMPTY_HASH]]
           end
+        end
+
+        # @api private
+        def constructor_type
+          ::Dry::Types::Array::Constructor
         end
       end
     end

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -184,7 +184,7 @@ module Dry
         if type.respond_to?(method)
           response = type.__send__(method, *args, &block)
 
-          if composable?(response)
+          if response.is_a?(Type) && type.class == response.class
             response.constructor_type.new(response, options)
           else
             response
@@ -192,11 +192,6 @@ module Dry
         else
           super
         end
-      end
-
-      # @api private
-      def composable?(value)
-        value.is_a?(Builder)
       end
     end
   end

--- a/lib/dry/types/hash/constructor.rb
+++ b/lib/dry/types/hash/constructor.rb
@@ -21,11 +21,11 @@ module Dry
           type.lax.constructor(fn, meta: meta)
         end
 
-        private
-
-        # @api private
-        def composable?(value)
-          super && !value.is_a?(Schema::Key)
+        # @see Dry::Types::Array#of
+        #
+        # @api public
+        def schema(*args)
+          type.schema(*args).constructor(fn, meta: meta)
         end
       end
     end

--- a/lib/dry/types/lax.rb
+++ b/lib/dry/types/lax.rb
@@ -67,7 +67,7 @@ module Dry
       #
       # @api private
       def decorate?(response)
-        super || response.is_a?(constructor_type)
+        super || response.is_a?(type.constructor_type)
       end
     end
 

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -8,6 +8,7 @@ module Dry
         Nominal => :visit_nominal,
         Constructor => :visit_constructor,
         Hash::Constructor => :visit_constructor,
+        Array::Constructor => :visit_constructor,
         Constrained => :visit_constrained,
         Constrained::Coercible => :visit_constrained,
         Hash => :visit_hash,

--- a/lib/dry/types/schema/key.rb
+++ b/lib/dry/types/schema/key.rb
@@ -96,7 +96,7 @@ module Dry
         #
         # @api public
         def lax
-          super.required(false)
+          __new__(type.lax).required(false)
         end
 
         # Dump to internal AST representation

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -141,6 +141,20 @@ RSpec.describe Dry::Types::Array do
         end
       end
     end
+
+    context 'nested array' do
+      let(:strings) do
+        Dry::Types['array'].of('string')
+      end
+
+      subject(:type) do
+        Dry::Types['array'].of(strings)
+      end
+
+      it 'still discards constructor' do
+        expect(type.constructor(&:to_a).member.type).to eql(strings)
+      end
+    end
   end
 
   describe '#to_s' do

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -118,6 +118,29 @@ RSpec.describe Dry::Types::Array do
         expect(type.to_s).to eql('#<Dry::Types[Array<Nominal<String>>]>')
       end
     end
+
+    describe '#constructor' do
+      subject(:type) { Dry::Types['params.array<params.integer>'] }
+
+      example 'getting member from a constructor type' do
+        expect(type.member.('1')).to be(1)
+      end
+
+      describe '#lax' do
+        subject(:type) { Dry::Types['array<integer>'].constructor(&:to_a) }
+
+        it 'makes type recursively lax' do
+          expect(type.lax.member).to eql(Dry::Types['nominal.integer'])
+        end
+      end
+
+      describe '#constrained' do
+        it 'applies constraints on top of constructor' do
+          expect(type.constrained(size: 1).(['1'])).to eql([1])
+          expect(type.constrained(size: 1).([]) { :fallback }).to be(:fallback)
+        end
+      end
+    end
   end
 
   describe '#to_s' do

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Dry::Types::Compiler, '#call' do
 
     array = compiler.(ast)
 
-    expect(array.type.member.primitive).to be(String)
+    expect(array.member.primitive).to be(String)
   end
 
   it 'builds a json hash from a :json_hash node' do

--- a/spec/dry/types/lax_spec.rb
+++ b/spec/dry/types/lax_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe Dry::Types::Nominal, '#lax' do
     it 'rescues from type-errors and returns input' do
       expect(type[age: 'wat', active: '1']).to eql(age: 'wat', active: true)
     end
+
+    it "doesn't decorate keys" do
+      expect(type.key(:age)).to be_a(Dry::Types::Schema::Key)
+      expect(type.key(:age).('23')).to eql(23)
+    end
   end
 
   context 'with an array' do

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -72,6 +72,20 @@ RSpec.describe Dry::Types::Schema do
     it 'discards schema constructor' do
       expect(schema.constructor(&:to_hash).key(:name)).to be(schema.name_key_map[:name])
     end
+
+    context 'nested schema' do
+      let(:name_schema) do
+        Dry::Types['hash'].schema(first_name: 'string', last_name: 'string')
+      end
+
+      subject(:schema) do
+        Dry::Types['hash'].schema(name: name_schema)
+      end
+
+      it 'still discards constructor' do
+        expect(schema.constructor(&:to_hash).key(:name).type).to eql(name_schema)
+      end
+    end
   end
 
   describe '#call' do


### PR DESCRIPTION
This fixes a few corner cases when using array types. One specific was reported by @solnic 

```ruby
Dry::Types['params.array<params.integer>'].member.('1')
# => Dry::Types::CoercionError: "1" cannot be coerced to array
# from /Users/gordon/dev/dry-rb/dry-types/lib/dry/types/coercions/params.rb:125:in `to_ary'
```

Now it works fine. This is the same solution we have for hash constructors so it potentially can be generalized but atm I just want to fix it as it is.