### PR TITLE
Use Types::{Array,Hash} as nominal types in `Constructor` when called with Array and Hash respectively

### DIFF
--- a/lib/dry/types/builder_methods.rb
+++ b/lib/dry/types/builder_methods.rb
@@ -82,7 +82,15 @@ module Dry
       #
       # @return [Dry::Types::Type]
       def Constructor(klass, cons = nil, &block)
-        Nominal.new(klass).constructor(cons || block || klass.method(:new))
+        nominal = if klass <= ::Array
+                    Array.new(klass)
+                  elsif klass <= ::Hash
+                    Hash.new(klass)
+                  else
+                    Nominal.new(klass)
+                  end
+
+        nominal.constructor(cons || block || klass.method(:new))
       end
 
       # Build a nominal type

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe Dry::Types::Module do
         expect(type['foo']).to eql('foo')
         expect { type[1] }.to raise_error(Dry::Types::CoercionError)
       end
+
+      it 'uses Types::Array for arrays' do
+        array = method(:Array)
+        expect(mod.Constructor(Array, array)).to eql(
+          Dry::Types['nominal.array'].constructor(array)
+        )
+      end
+
+      it 'uses Types::Hash for hashes' do
+        hash = method(:Hash)
+        expect(mod.Constructor(Hash, hash)).to eql(
+          Dry::Types['nominal.hash'].constructor(hash)
+        )
+      end
     end
 
     describe '.Nominal' do


### PR DESCRIPTION
Addresses https://github.com/dry-rb/dry-schema/issues/171
But this is only part of the solution, the second part is not allowing nested schemas on non-generic types.