### PR TITLE
Empty strings for integer params should be coerced to nil

### DIFF
--- a/lib/dry/types/coercions/params.rb
+++ b/lib/dry/types/coercions/params.rb
@@ -66,7 +66,9 @@ module Dry
         #
         # @api public
         def self.to_int(input, &block)
-          if input.is_a? String
+          if empty_str?(input)
+            nil
+          elsif input.is_a? String
             Integer(input, 10)
           else
             Integer(input)

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe Dry::Types::Nominal do
     it_behaves_like 'a constrained type', inputs: [
       Object.new, 'foo', '23asf', {}
     ]
+    
+    it 'coerces empty string to nil' do
+      expect(type['']).to be(nil)
+    end
 
     it 'coerces to an integer' do
       expect(type['312']).to be(312)


### PR DESCRIPTION
Coerce empty string integer params to `nil`, to fix #344.