### PR TITLE
Add Types::Optional::Params

### DIFF
--- a/lib/dry/types/params.rb
+++ b/lib/dry/types/params.rb
@@ -55,5 +55,10 @@ module Dry
     register('params.symbol') do
       self['nominal.symbol'].constructor(Coercions::Params.method(:to_symbol))
     end
+
+    COERCIBLE.each_key do |name|
+      next if name.equal?(:string)
+      register("optional.params.#{name}", self['params.nil'] | self["params.#{name}"])
+    end
   end
 end

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -219,4 +219,20 @@ RSpec.describe Dry::Types::Nominal do
       expect(type['a']).to eql(:a)
     end
   end
+
+  context 'optional types' do
+    subject(:type) { Dry::Types['optional.params.integer'] }
+
+    it 'coerces empty strings to nil' do
+      expect(type['']).to be_nil
+    end
+
+    it 'parses integers' do
+      expect(type['40']).to be(40)
+    end
+
+    it 'raises an error on random strings' do
+      expect { type['abc'] }.to raise_error(Dry::Types::CoercionError)
+    end
+  end
 end


### PR DESCRIPTION
```ruby
[1] pry(main)> Types::Optional::Params::Integer.('99')
=> 99
[2] pry(main)> Types::Optional::Params::Integer.('')
=> nil
```

Note that `Dry::Types['optional.params.integer']` is not the same as `Types::Params::Integer.optional`. It would be a breaking change, it's also not clear whether we want this.