### PR TITLE
Add monads extension

### DIFF
--- a/lib/dry/types/extensions.rb
+++ b/lib/dry/types/extensions.rb
@@ -3,3 +3,7 @@
 Dry::Types.register_extension(:maybe) do
   require 'dry/types/extensions/maybe'
 end
+
+Dry::Types.register_extension(:monads) do
+  require 'dry/types/extensions/monads'
+end

--- a/lib/dry/types/extensions/monads.rb
+++ b/lib/dry/types/extensions/monads.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'dry/monads/result'
+
+module Dry
+  module Types
+    # Monad extension for Result
+    #
+    # @api public
+    class Result
+      include Dry::Monads::Result::Mixin
+
+      # Turn result into a monad
+      #
+      # This makes result objects work with dry-monads (or anything with a compatible interface)
+      #
+      # @return [Dry::Monads::Success,Dry::Monads::Failure]
+      #
+      # @api public
+      def to_monad
+        if success?
+          Success(input)
+        else
+          Failure([error, input])
+        end
+      end
+    end
+  end
+end

--- a/spec/extensions/monads/result_spec.rb
+++ b/spec/extensions/monads/result_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Types::Result do
+  before { Dry::Types.load_extensions(:monads) }
+
+  let(:type) { Dry::Types['strict.string'] }
+
+  let(:result) { type.try(input) }
+
+  context 'interface' do
+    let(:input) { {} }
+
+    it 'responds to #to_monad' do
+      expect(result).to respond_to(:to_monad)
+    end
+  end
+
+  context 'with valid input' do
+    let(:input) { 'Jane' }
+
+    describe '#to_monad' do
+      it 'wraps Result with Success' do
+        monad = result.to_monad
+
+        expect(monad).to be_a Dry::Monads::Result
+        expect(monad).to be_success
+        expect(monad.value!).to eq(result.input)
+      end
+    end
+  end
+
+  context 'with invalid input' do
+    let(:input) { nil }
+
+    describe '#to_monad' do
+      it 'wraps Result with Failure' do
+        monad = result.to_monad
+
+        expect(monad).to be_a Dry::Monads::Result
+        expect(monad).to be_failure
+        expect(monad.failure).to eq([result.error, result.input])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This extension adds `.to_monad` method which replaces `Dry::Types::Result` with `Dry::Monads::Result`:

```ruby
Dry::Types.load_extensions(:monads)

result = Dry::Types['strict.string'].try('Jane')
result.class #=> Dry::Types::Result::Success
monad = result.to_monad
monad.class #=> Dry::Monads::Result::Success
monad.value!  # => 'Jane'

result = Dry::Types['strict.string'].try(nil)
result.class #=> Dry::Types::Failure
monad = result.to_monad
monad.class #=> Dry::Monads::Result::Failure
monad.failure  # => [#<Dry::Types::ConstraintError>, nil]
```

Closes #325 