### PR TITLE
Fixing codeblock in maybe.html.md

### DIFF
--- a/docsite/source/extensions/maybe.html.md
+++ b/docsite/source/extensions/maybe.html.md
@@ -9,14 +9,14 @@ The [dry-monads gem](/gems/dry-monads/) provides approach to handling optional v
 > NOTE: Requires the [dry-monads gem](/gems/dry-monads/) to be loaded.
 1. Load the `:maybe` extension in your application.
 
-    ```ruby
-    require 'dry-types'
-    
-    Dry::Types.load_extensions(:maybe)
-    module Types
-      include Dry.Types()
-    end
-    ```
+```ruby
+require 'dry-types'
+
+Dry::Types.load_extensions(:maybe)
+module Types
+  include Dry.Types()
+end
+```
 
 2. Append `.maybe` to a _Type_ to return a _Monad_ object  
 


### PR DESCRIPTION
Currently it is not taken as ruby code because the
spaces at the beginning