### PR TITLE
Fix error on Dry::Types::Array#try

### DIFF
--- a/lib/dry/types/array/member.rb
+++ b/lib/dry/types/array/member.rb
@@ -89,7 +89,7 @@ module Dry
               block ? yield(failure) : failure
             end
           else
-            failure = failure(input, "#{input} is not an array")
+            failure = failure(input, CoercionError.new("#{input} is not an array"))
             block ? yield(failure) : failure
           end
         end

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -19,6 +19,36 @@ RSpec.describe Dry::Types::Array do
         include_context 'array with a member type'
       end
 
+      context 'try' do
+        subject(:array) do
+          Dry::Types['nominal.array'].of(Dry::Types['strict.string'])
+        end
+
+        it 'with a valid array' do
+          expect(array.try(%w[a b])).to be_success
+        end
+
+        it 'an invalid type should be a failure' do
+          expect(array.try('some string')).to be_failure
+        end
+
+        it 'a broken constraint should be a failure' do
+          expect(array.try(['1', 2])).to be_failure
+        end
+
+        it 'a broken constraint with block' do
+          expect(
+            array.try(['1', '2', 3]) { |error| "error: #{error}" }
+          ).to match(/error: 3/)
+        end
+
+        it 'an invalid type with a block' do
+          expect(
+            array.try('X') { |x| 'error: ' + x.to_s }
+          ).to eql('error: X is not an array')
+        end
+      end
+
       context 'using method' do
         subject(:array) { Dry::Types['coercible.array'].of(Dry::Types['coercible.string']) }
 


### PR DESCRIPTION
One of the branches was calling `Nominal#failure` with a wrong parameter, and that was causing an exception that should not be happening.

Also adding more spec for `Dry::Types::Array#try`