### PR TITLE
Don't build constructors when class implementing type interface given

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :test do
   platform :mri do
     gem 'simplecov', require: false
   end
+
+  gem 'dry-struct'
 end
 
 group :tools do

--- a/lib/dry/types/builder_methods.rb
+++ b/lib/dry/types/builder_methods.rb
@@ -83,7 +83,11 @@ module Dry
       # @return [Dry::Types::Type]
       def Constructor(klass, cons = nil, &block)
         if klass.is_a?(Type)
-          klass.constructor(cons || block || klass.method(:new))
+          if cons || block
+            klass.constructor(cons || block)
+          else
+            klass
+          end
         else
           Nominal(klass).constructor(cons || block || klass.method(:new))
         end

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'dry-struct'
 require 'spec_helper'
 
 RSpec.describe Dry::Types::Module do
@@ -92,6 +93,14 @@ RSpec.describe Dry::Types::Module do
         expect(mod.Constructor(Dry::Types['nominal.string'], &to_s)).to eql(
           mod.Constructor(String, &to_s)
         )
+      end
+
+      context 'with struct' do
+        let(:user_struct) { Dry.Struct(name: 'string') }
+
+        it 'returns struct back if no constructor block provided' do
+          expect(mod.Constructor(user_struct)).to be(user_struct)
+        end
       end
     end
 


### PR DESCRIPTION
There is no point in doing this. Moreover, Dry::Struct::Constructor doesn't implement all type methods (for some reasons, I guess) and it led to regressions in hanami-model.