### PR TITLE
Fix typo in doc: Remove duplicated dot from Hash Schemas example

### DIFF
--- a/docsite/source/extensions/maybe.html.md
+++ b/docsite/source/extensions/maybe.html.md
@@ -9,14 +9,14 @@ The [dry-monads gem](/gems/dry-monads/) provides approach to handling optional v
 > NOTE: Requires the [dry-monads gem](/gems/dry-monads/) to be loaded.
 1. Load the `:maybe` extension in your application.
 
-    ```ruby
-    require 'dry-types'
-    
-    Dry::Types.load_extensions(:maybe)
-    module Types
-      include Dry.Types()
-    end
-    ```
+```ruby
+require 'dry-types'
+
+Dry::Types.load_extensions(:maybe)
+module Types
+  include Dry.Types()
+end
+```
 
 2. Append `.maybe` to a _Type_ to return a _Monad_ object  
 

--- a/docsite/source/hash-schemas.html.md
+++ b/docsite/source/hash-schemas.html.md
@@ -143,7 +143,7 @@ user_hash[{}]
 Type transformations work perfectly with inheritance, you don't have to define same rules more than once:
 
 ```ruby
-SymbolizeAndOptionalSchema = Types::Hash.
+SymbolizeAndOptionalSchema = Types::Hash
   .schema({})
   .with_key_transform(&:to_sym)
   .with_type_transform { |type| type.required(false) }


### PR DESCRIPTION
Two method dots in a row is not valid Ruby.

It looks like the dots were moved to the start of the newlines between:

https://dry-rb.org/gems/dry-types/0.15/hash-schemas/#transforming-types

and 

https://dry-rb.org/gems/dry-types/1.2/hash-schemas/#transforming-types

which resulted in an extra one being left in.