### PR TITLE
Accept Time/Date/DateTime and booleans in JSON and Params types

### DIFF
--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -39,6 +39,8 @@ module Dry
           rescue ArgumentError, RangeError => e
             CoercionError.handle(e, &block)
           end
+        elsif input.is_a?(::Date)
+          input
         elsif block_given?
           yield
         else
@@ -60,6 +62,8 @@ module Dry
           rescue ArgumentError => e
             CoercionError.handle(e, &block)
           end
+        elsif input.is_a?(::DateTime)
+          input
         elsif block_given?
           yield
         else
@@ -81,6 +85,8 @@ module Dry
           rescue ArgumentError => e
             CoercionError.handle(e, &block)
           end
+        elsif input.is_a?(::Time)
+          input
         elsif block_given?
           yield
         else

--- a/lib/dry/types/coercions/params.rb
+++ b/lib/dry/types/coercions/params.rb
@@ -14,7 +14,7 @@ module Dry
         FALSE_VALUES = %w[0 off Off OFF f false False FALSE F n no No NO N].freeze
         BOOLEAN_MAP = ::Hash[
           TRUE_VALUES.product([true]) + FALSE_VALUES.product([false])
-        ].freeze
+        ].merge(true => true, false => false).freeze
 
         extend Coercions
 

--- a/spec/dry/types/types/json_spec.rb
+++ b/spec/dry/types/types/json_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe Dry::Types::Nominal do
     it 'coerces to a date' do
       expect(type['2015-11-26']).to eql(Date.new(2015, 11, 26))
     end
+
+    it 'accepts date' do
+      date = Date.new(2015, 11, 26)
+
+      expect(type[date]).to be(date)
+    end
   end
 
   describe 'json.date_time' do
@@ -35,6 +41,11 @@ RSpec.describe Dry::Types::Nominal do
     it 'coerces to a date time' do
       expect(type['2015-11-26 12:00:00']).to eql(DateTime.new(2015, 11, 26, 12))
     end
+
+    it 'accepts datetime' do
+      datetime = DateTime.new(2015, 11, 26, 12)
+      expect(type[datetime]).to be(datetime)
+    end
   end
 
   describe 'json.time' do
@@ -46,6 +57,11 @@ RSpec.describe Dry::Types::Nominal do
 
     it 'coerces to a time' do
       expect(type['2015-11-26 12:00:00']).to eql(Time.new(2015, 11, 26, 12))
+    end
+
+    it 'accepts time' do
+      time = Time.new(2015, 11, 26, 12)
+      expect(type[time]).to be(time)
     end
   end
 

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe Dry::Types::Nominal do
         type['Thu, 26 Nov 2015 00:00:00 GMT']
       ]).to all(eql(Date.new(2015, 11, 26)))
     end
+
+    it 'accepts date' do
+      date = Date.new(2015, 11, 26)
+
+      expect(type[date]).to be(date)
+    end
   end
 
   describe 'params.date_time' do
@@ -51,6 +57,11 @@ RSpec.describe Dry::Types::Nominal do
     it 'coerces to a date time' do
       expect(type['2015-11-26 12:00:00']).to eql(DateTime.new(2015, 11, 26, 12))
     end
+
+    it 'accepts datetime' do
+      datetime = DateTime.new(2015, 11, 26, 12)
+      expect(type[datetime]).to be(datetime)
+    end
   end
 
   describe 'params.time' do
@@ -62,6 +73,11 @@ RSpec.describe Dry::Types::Nominal do
 
     it 'coerces to a time' do
       expect(type['2015-11-26 12:00:00']).to eql(Time.new(2015, 11, 26, 12))
+    end
+
+    it 'accepts time' do
+      time = Time.new(2015, 11, 26, 12)
+      expect(type[time]).to be(time)
     end
   end
 
@@ -83,6 +99,11 @@ RSpec.describe Dry::Types::Nominal do
         expect(type[value]).to be(false)
       end
     end
+
+    it 'accepts true and false' do
+      expect(type[true]).to be(true)
+      expect(type[false]).to be(false)
+    end
   end
 
   describe 'params.true' do
@@ -97,6 +118,10 @@ RSpec.describe Dry::Types::Nominal do
         expect(type[value]).to be(true)
       end
     end
+
+    it 'accepts true' do
+      expect(type[true]).to be(true)
+    end
   end
 
   describe 'params.false' do
@@ -110,6 +135,10 @@ RSpec.describe Dry::Types::Nominal do
       %w[0 off f false n no].each do |value|
         expect(type[value]).to be(false)
       end
+    end
+
+    it 'accepts false' do
+      expect(type[false]).to be(false)
     end
   end
 


### PR DESCRIPTION
It can be useful in tests or similar places where you want to pass a coerced value to a type. However, if you rely on this behavior in production, chances are this is a smell in your code. 