### PR TITLE
Add `Dry::Types::Hash::Schema.merge`

### DIFF
--- a/docsite/source/hash-schemas.html.md
+++ b/docsite/source/hash-schemas.html.md
@@ -124,6 +124,29 @@ user_hash['name' => 'Jane', 'city' => 'London']
 # => Dry::Types::UnknownKeysError: unexpected keys [:city] in Hash input
 ```
 
+### Merging schemas
+
+Similar than inheritance, two schemas can be merged.
+The resulting schema will have the sum of both sets
+of attributes.
+
+user_hash = Types::Hash.schema(
+  name: Types::String
+)
+
+address_hash = Types::Hash.schema(
+  address: Types::String
+)
+
+user_with_address_schema = user_hash.merge(address_hash)
+
+user_with_address_schema['name' => 'Jane', 'address' => 'C/ Foo']
+# => { name: 'Jane', address: 'C/ Foo' }
+```
+
+Keep in mind that key transformations from the caller schema are preserved,
+while each attribute keeps the type transformations from its original hash.
+
 ### Transforming types
 
 A schema can transform types with a block. For example, the following code makes all keys optional:

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -284,6 +284,18 @@ module Dry
         Lax.new(schema(keys.map(&:lax)))
       end
 
+      # Merges given schema keys into current schema.
+      #
+      # A new instance is returned.
+      #
+      # @param schema [Schema]
+      # @return [Schema]
+      #
+      # @api public
+      def merge(other)
+        schema(other.keys)
+      end
+
       private
 
       # @param [Array<Dry::Types::Schema::Keys>] keys


### PR DESCRIPTION
It's also aliased as `.compose`.

I submit this PR in relation with https://github.com/dry-rb/dry-struct/pull/139

It moves composition to the fundamental piece of a `Dry::Struct`, a `Dry::Types::Hash::Schema`.

If this PR is accepted I'll modify the other one accordingly so it makes use of the new method.

Key transformation and type transformation work in a different way due to how they are implemented, but I haven't studied why it is this way. Any feedback is welcomed :)