### PR TITLE
Add aliases for .constructor

### DIFF
--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -129,6 +129,10 @@ module Dry
       def constructor(constructor = nil, **options, &block)
         constructor_type.new(with(**options), fn: constructor || block)
       end
+      alias_method :append, :constructor
+      alias_method :prepend, :constructor
+      alias_method :>>, :constructor
+      alias_method :<<, :constructor
     end
   end
 end

--- a/lib/dry/types/lax.rb
+++ b/lib/dry/types/lax.rb
@@ -15,7 +15,7 @@ module Dry
       include Printable
       include Dry::Equalizer(:type, inspect: false, immutable: true)
 
-      undef :options, :constructor
+      undef :options, :constructor, :<<, :>>, :prepend, :append
 
       # @param [Object] input
       #

--- a/lib/dry/types/spec/types.rb
+++ b/lib/dry/types/spec/types.rb
@@ -139,3 +139,14 @@ RSpec.shared_examples_for 'a nominal type' do |inputs: Object.new|
     end
   end
 end
+
+RSpec.shared_examples_for 'a composable constructor' do
+  describe '#constructor' do
+    it 'has aliases for composition' do
+      expect(type.method(:append)).to eql(type.method(:constructor))
+      expect(type.method(:prepend)).to eql(type.method(:constructor))
+      expect(type.method(:<<)).to eql(type.method(:constructor))
+      expect(type.method(:>>)).to eql(type.method(:constructor))
+    end
+  end
+end

--- a/spec/dry/types/array_spec.rb
+++ b/spec/dry/types/array_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Dry::Types::Array do
 
         it_behaves_like Dry::Types::Nominal do
           subject(:type) { array }
+
+          it_behaves_like 'a composable constructor'
         end
       end
 

--- a/spec/dry/types/constrained_spec.rb
+++ b/spec/dry/types/constrained_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Dry::Types::Constrained do
     it_behaves_like Dry::Types::Nominal
     it_behaves_like 'Dry::Types::Nominal#meta'
     it_behaves_like 'a constrained type'
+    it_behaves_like 'a composable constructor'
   end
 
   describe '#[]' do

--- a/spec/dry/types/enum_spec.rb
+++ b/spec/dry/types/enum_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Dry::Types::Enum do
 
     it_behaves_like Dry::Types::Nominal
     it_behaves_like 'a constrained type'
+    it_behaves_like 'a composable constructor'
 
     it 'allows defining an enum from a specific type' do
       expect(type['draft']).to eql(mapping.key(0))
@@ -41,6 +42,7 @@ RSpec.describe Dry::Types::Enum do
     let(:string) { Dry::Types['strict.string'] }
 
     it_behaves_like Dry::Types::Nominal
+    it_behaves_like 'a composable constructor'
 
     it 'allows defining an enum from a specific type' do
       expect(type['draft']).to eql(values[0])

--- a/spec/dry/types/map_spec.rb
+++ b/spec/dry/types/map_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Dry::Types::Map do
     let(:type) { Dry::Types::Map.new(::Hash) }
 
     it_behaves_like 'Dry::Types::Nominal#meta'
-
     it_behaves_like Dry::Types::Nominal
     it_behaves_like 'a constrained type'
+    it_behaves_like 'a composable constructor'
   end
 
   context 'options' do

--- a/spec/dry/types/nominal_spec.rb
+++ b/spec/dry/types/nominal_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Dry::Types::Nominal do
   subject(:type) { Dry::Types::Nominal.new(String) }
 
   it_behaves_like 'Dry::Types::Nominal#meta'
+  it_behaves_like 'a composable constructor'
 
   it 'is frozen' do
     expect(type).to be_frozen

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Dry::Types::Schema do
 
   it_behaves_like 'a constrained type' do
     let(:type) { schema }
+
+    it_behaves_like 'a composable constructor'
   end
 
   describe '#each' do
@@ -152,10 +154,14 @@ RSpec.describe Dry::Types::Schema do
 
     it_behaves_like Dry::Types::Nominal do
       let(:type) { Dry::Types['nominal.hash'].schema(hash_schema) }
+
+      it_behaves_like 'a composable constructor'
     end
 
     it_behaves_like 'Dry::Types::Nominal#meta' do
       let(:type) { Dry::Types['nominal.hash'].schema(hash_schema) }
+
+      it_behaves_like 'a composable constructor'
     end
 
     context 'members with default values' do

--- a/spec/dry/types/sum_spec.rb
+++ b/spec/dry/types/sum_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Dry::Types::Sum do
     subject(:type) { Dry::Types['bool'] }
 
     it_behaves_like 'Dry::Types::Nominal#meta'
-
     it_behaves_like 'Dry::Types::Nominal without primitive'
+    it_behaves_like 'a composable constructor'
 
     it 'is frozen' do
       expect(type).to be_frozen
@@ -15,6 +15,8 @@ RSpec.describe Dry::Types::Sum do
 
   it_behaves_like 'a constrained type' do
     let(:type) { Dry::Types['integer'] | Dry::Types['string'] }
+
+    it_behaves_like 'a composable constructor'
   end
 
   describe '#optional?' do

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Dry::Types::Nominal do
     it_behaves_like 'a constrained type', inputs: [
       Object.new, 'huh?'
     ]
+    it_behaves_like 'a composable constructor'
 
     it 'coerces to true' do
       (Dry::Types::Coercions::Params::TRUE_VALUES + [1]).each do |value|


### PR DESCRIPTION
This allows not to bother about which kind of type you have and call `.append`/`.prepend` whenever you like. It improves ergonomics for the sake of type interface size. However, these methods are just aliases and shouldn't be a major problem.