### PR TITLE
Shows meta usage in intro doc

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -104,6 +104,9 @@ class User < Dry::Struct
   attribute :name, Types::String
   attribute :age,  Types::Integer.meta(info: 'extra info about age')
 end
+
+User.schema.key(:age).meta
+# => {:info=>"extra info about age"}
 ```
 
 - Pass values directly to `Dry::Types` without creating an object using `[]`:


### PR DESCRIPTION
Small update on the docs for meta usage to show how to get the metadata. Not sure if this is documented somewhere but personally I couldn't find it.

Thank you @solnic  for your support in https://discourse.dry-rb.org/t/how-to-access-meta-fields-in-structs/989 