### PR TITLE
Add strict types as default to optional namespace

### DIFF
--- a/lib/dry/types/core.rb
+++ b/lib/dry/types/core.rb
@@ -72,7 +72,9 @@ module Dry
 
     # Register optional strict {NON_NIL} types
     NON_NIL.each_key do |name|
-      register("optional.strict.#{name}", self["strict.#{name}"].optional)
+      type = self[name.to_s].optional
+      register("optional.strict.#{name}", type)
+      register("optional.#{name}", type)
     end
 
     # Register optional {COERCIBLE} types

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe Dry::Types::Module do
         let(:kwargs) { { default: :strict } }
 
         it 'adds strict types as default' do
-          expect(mod::Integer).to be(Dry::Types['strict.integer'])
+          expect(mod::Integer).to be(Dry::Types['integer'])
           expect(mod::Nominal::Integer).to be(Dry::Types['nominal.integer'])
           expect { mod::Params }.to raise_error(NameError)
         end
@@ -251,6 +251,10 @@ RSpec.describe Dry::Types::Module do
           expect(mod::Strict::Integer).to be_optional
           expect(mod::Coercible::Integer).to be_optional
         end
+      end
+
+      example 'default types in optional ns are strict' do
+        expect(mod::Optional::String).to eql(mod::String.optional)
       end
     end
 

--- a/spec/dry/types_spec.rb
+++ b/spec/dry/types_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe Dry::Types do
     it 'returns unregistered types back' do
       expect(Dry::Types[unregistered_type]).to be(unregistered_type)
     end
+
+    it 'has strict types as default in optional namespace' do
+      expect(Dry::Types['optional.string']).to eql(Dry::Types['string'].optional)
+    end
   end
 
   describe 'missing constant' do


### PR DESCRIPTION
```ruby
Types::Optional::String # => strict optional string
Dry::Types['optional.integer'] # => strict optional integer
```