### PR TITLE
Add Params::String

### DIFF
--- a/lib/dry/types/params.rb
+++ b/lib/dry/types/params.rb
@@ -56,6 +56,10 @@ module Dry
       self['nominal.symbol'].constructor(Coercions::Params.method(:to_symbol))
     end
 
+    register('params.string') do
+      self['nominal.string'].constructor(Kernel.method(:String))
+    end
+
     COERCIBLE.each_key do |name|
       next if name.equal?(:string)
 

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -265,4 +265,12 @@ RSpec.describe Dry::Types::Nominal do
       expect { type['abc'] }.to raise_error(Dry::Types::CoercionError)
     end
   end
+
+  describe 'params.string' do
+    subject(:type) { Dry::Types['params.string'] }
+
+    it 'is an alias for coercible.string' do
+      expect(type).to eql(Dry::Types['coercible.string'])
+    end
+  end
 end


### PR DESCRIPTION
This type will use `Kernel.String` to cast data to a string