### PR TITLE
Revert adding Params::String

### DIFF
--- a/lib/dry/types/params.rb
+++ b/lib/dry/types/params.rb
@@ -56,10 +56,6 @@ module Dry
       self['nominal.symbol'].constructor(Coercions::Params.method(:to_symbol))
     end
 
-    register('params.string') do
-      self['nominal.string'].constructor(Kernel.method(:String))
-    end
-
     COERCIBLE.each_key do |name|
       next if name.equal?(:string)
 

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -265,12 +265,4 @@ RSpec.describe Dry::Types::Nominal do
       expect { type['abc'] }.to raise_error(Dry::Types::CoercionError)
     end
   end
-
-  describe 'params.string' do
-    subject(:type) { Dry::Types['params.string'] }
-
-    it 'is an alias for coercible.string' do
-      expect(type).to eql(Dry::Types['coercible.string'])
-    end
-  end
 end


### PR DESCRIPTION
It broke dry-schema because it gives priority to `params.string` over `strict.string` which makes perfect sense. It's very unsafe to coerce arbitrary input to strings. Params also support other types than strings, like hashes; implicitly casting them to strings is way off. I'm revering this change, users can write their own constructor types where needed.