### PR TITLE
Infer hash? predicate for hash schemas

### DIFF
--- a/lib/dry/types/predicate_inferrer.rb
+++ b/lib/dry/types/predicate_inferrer.rb
@@ -71,6 +71,7 @@ module Dry
         def visit_hash(_)
           HASH
         end
+        alias_method :visit_schema, :visit_hash
 
         # @api private
         def visit_array(_)

--- a/spec/dry/types/predicate_inferrer_spec.rb
+++ b/spec/dry/types/predicate_inferrer_spec.rb
@@ -82,6 +82,17 @@ RSpec.describe Dry::Types::PredicateInferrer, '#[]' do
     expect(inferrer[type(:any)]).to eql([])
   end
 
+  it 'returns hash? for hash' do
+    expect(inferrer[type(:hash)]).to eql([:hash?])
+  end
+
+  # it is a compromise
+  # inferring complex schemas as predicates
+  # is not our goal at this point
+  it 'returns hash? for schemas' do
+    expect(inferrer[type(:hash).schema(name: 'string')]).to eql([:hash?])
+  end
+
   context 'constrained types' do
     it 'extracts predicates from contrained types' do
       expect(inferrer[type(:integer).constrained(gteq: 18)]).to eql([:int?, gteq?: 18])


### PR DESCRIPTION
We have no plans inferring more complex checks ATM. Instead, dry-schema will iterate over schemas keys and add them one-by-one.