### PR TITLE
Do not coerce empty strings to nil in json.nil

### DIFF
--- a/lib/dry/types/coercions.rb
+++ b/lib/dry/types/coercions.rb
@@ -8,23 +8,6 @@ module Dry
     module Coercions
       include Dry::Core::Constants
 
-      # @param [String, Object] input
-      #
-      # @return [nil] if the input is an empty string or nil
-      #
-      # @raise CoercionError
-      #
-      # @api public
-      def to_nil(input, &_block)
-        if input.nil? || empty_str?(input)
-          nil
-        elsif block_given?
-          yield
-        else
-          raise CoercionError, "#{input.inspect} is not nil"
-        end
-      end
-
       # @param [#to_str, Object] input
       #
       # @return [Date, Object]

--- a/lib/dry/types/coercions/json.rb
+++ b/lib/dry/types/coercions/json.rb
@@ -14,6 +14,23 @@ module Dry
       module JSON
         extend Coercions
 
+        # @param [Object] input
+        #
+        # @return [nil] if the input is nil
+        #
+        # @raise CoercionError
+        #
+        # @api public
+        def self.to_nil(input, &_block)
+          if input.nil?
+            nil
+          elsif block_given?
+            yield
+          else
+            raise CoercionError, "#{input.inspect} is not nil"
+          end
+        end
+
         # @param [#to_d, Object] input
         #
         # @return [BigDecimal,nil]

--- a/lib/dry/types/coercions/params.rb
+++ b/lib/dry/types/coercions/params.rb
@@ -18,6 +18,23 @@ module Dry
 
         extend Coercions
 
+        # @param [Object] input
+        #
+        # @return [nil] if the input is an empty string or nil
+        #
+        # @raise CoercionError
+        #
+        # @api public
+        def self.to_nil(input, &_block)
+          if input.nil? || empty_str?(input)
+            nil
+          elsif block_given?
+            yield
+          else
+            raise CoercionError, "#{input.inspect} is not nil"
+          end
+        end
+
         # @param [String, Object] input
         #
         # @return [Boolean,Object]

--- a/spec/dry/types/types/json_spec.rb
+++ b/spec/dry/types/types/json_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Dry::Types::Nominal do
       Object.new, 'foo', %w[foo]
     ]
 
-    it 'coerces empty string to nil' do
-      expect(type['']).to be(nil)
+    it 'rejects empty string' do
+      expect(type.('') { :fallback }).to eql(:fallback)
     end
   end
 


### PR DESCRIPTION
JSON has values for `nil` and `''`: `null` and `""`. Coercion empty strings to `nil` in JSON types is a long-standing bug which some code may rely on by now :( This has to be fixed nonetheless. Ref https://github.com/dry-rb/dry-schema/issues/229