### PR TITLE
Avoid YARD warnings

### DIFF
--- a/lib/dry/types/meta.rb
+++ b/lib/dry/types/meta.rb
@@ -11,7 +11,7 @@ module Dry
         @meta = meta.freeze
       end
 
-      # @param [Hash] new_options
+      # @param options [Hash] new_options
       #
       # @return [Type]
       #

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -98,7 +98,6 @@ module Dry
       end
 
       # @param [Object] input
-      # @param [#call,nil] block
       #
       # @yieldparam [Failure] failure
       # @yieldreturn [Result]

--- a/lib/dry/types/schema.rb
+++ b/lib/dry/types/schema.rb
@@ -83,7 +83,7 @@ module Dry
         call_unsafe(hash, options)
       end
 
-      # @param [Hash] hash
+      # @param input [Hash] hash
       #
       # @yieldparam [Failure] failure
       # @yieldreturn [Result]
@@ -288,7 +288,7 @@ module Dry
       #
       # A new instance is returned.
       #
-      # @param schema [Schema]
+      # @param other [Schema] schema
       # @return [Schema]
       #
       # @api public


### PR DESCRIPTION
This PR updates small details in the YARD annotations to make the API docs render with fewer warnings.

There were a few  API docs warnings:

> Building YARD (yri) index for dry-types-1.4.0...
lib/dry/types/meta.rb:14: [UnknownParam] @param tag has unknown parameter name: new_options. Did you mean `options`?
lib/dry/types/schema.rb:86: [UnknownParam] @param tag has unknown parameter name: hash
lib/dry/types/schema.rb:291: [UnknownParam] @param tag has unknown parameter name: schema
lib/dry/types/nominal.rb:101: [UnknownParam] @param tag has unknown parameter name: block