### PR TITLE
Document use of custom method in Constructor

### DIFF
--- a/docsite/source/custom-types.html.md
+++ b/docsite/source/custom-types.html.md
@@ -47,6 +47,9 @@ user_type = Types.Constructor(User)
 # It is equivalent to User.new(name: 'John')
 user_type[name: 'John']
 
+# Using a method User.build
+user_type = Types.Constructor(User, &:build)
+
 # Using a block
 user_type = Types.Constructor(User) { |values| User.new(values) }
 ```


### PR DESCRIPTION
Add example in `Types.Constructor` on how to use a custom method.

The documentation will now cover the signature of `Types.Constructor(klass, cons = nil, &block)` in full.