### PR TITLE
Docs: Removing Hash schema type param and fixing md section

### DIFF
--- a/docsite/source/custom-types.html.md
+++ b/docsite/source/custom-types.html.md
@@ -75,7 +75,7 @@ int['one'] # => 'one'
 Types::Hash.schema(name: Types::String, age: Types::Coercible::Integer)
 
 # Using Types.Hash()
-Types.Hash(:permissive, name: Types::String, age: Types::Coercible::Integer)
+Types.Hash(name: Types::String, age: Types::Coercible::Integer)
 ```
 
 ### `Types.Array`

--- a/docsite/source/hash-schemas.html.md
+++ b/docsite/source/hash-schemas.html.md
@@ -126,10 +126,11 @@ user_hash['name' => 'Jane', 'city' => 'London']
 
 ### Merging schemas
 
-Similar than inheritance, two schemas can be merged.
+Similar to inheritance, two schemas can be merged.
 The resulting schema will have the sum of both sets
 of attributes.
 
+```ruby
 user_hash = Types::Hash.schema(
   name: Types::String
 )


### PR DESCRIPTION
* Was getting param count errors on Types.Hash(:permissive, name: Types::String) and saw in the source where schema type params like that have been deprecated and raise via call to weak.

* Fixed md for Hash merge schema section.  