### PR TITLE
Cherry-pick “concurrent/map” require

### DIFF
--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -4,7 +4,7 @@ require 'bigdecimal'
 require 'date'
 require 'set'
 
-require 'concurrent'
+require 'concurrent/map'
 
 require 'dry-container'
 require 'dry-equalizer'


### PR DESCRIPTION
We don’t need the whole of the concurrent gem, just this one part of it.

This results in 242 fewer files loaded when requiring “dry/types”.