### PR TITLE
Add `#or_nil`

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,4 +1,8 @@
 ---
+- version: 1.5.0
+  date: '2020-12-14'
+  added:
+  - Add `#or_nil` to support nullifying invalid values (@ianks)
 - version: 1.4.0
   date: '2020-03-09'
   fixed:

--- a/changelog.yml
+++ b/changelog.yml
@@ -1,8 +1,4 @@
 ---
-- version: 1.5.0
-  date: '2020-12-14'
-  added:
-  - Add `#or_nil` to support nullifying invalid values (@ianks)
 - version: 1.4.0
   date: '2020-03-09'
   fixed:

--- a/docsite/source/or-nil.html.md
+++ b/docsite/source/or-nil.html.md
@@ -1,0 +1,17 @@
+---
+title: Or Nil
+layout: gem-single
+name: dry-types
+---
+
+Sometimes, it is useful to simply "nilify" invalid values instead failing. For example, imagine you want to accept `secondary_email` address, but it's OK to leave it nil if it is not valid. To accomplish this, you can:
+
+``` ruby
+secondary_email = Types::String.constrained(format: URI::MailTo::EMAIL_REGEXP).or_nil
+
+secondary_email["jane@doe.org"]
+# => "jane@doe.org"
+
+secondary_email["jane"]
+# => nil
+```

--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -117,6 +117,16 @@ module Dry
         Lax.new(self)
       end
 
+      # Turn a type into a or_nil type that will rescue from type-errors and
+      # return nil
+      #
+      # @return [OrNil]
+      #
+      # @api public
+      def or_nil
+        OrNil.new(self)
+      end
+
       # Define a constructor for the type
       #
       # @param [#call,nil] constructor
@@ -141,4 +151,5 @@ require 'dry/types/default'
 require 'dry/types/constrained'
 require 'dry/types/enum'
 require 'dry/types/lax'
+require 'dry/types/or_nil'
 require 'dry/types/sum'

--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -151,5 +151,5 @@ require 'dry/types/default'
 require 'dry/types/constrained'
 require 'dry/types/enum'
 require 'dry/types/lax'
-require 'dry/types/or_nil'
+require "dry/types/or_nil"
 require 'dry/types/sum'

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -40,6 +40,10 @@ module Dry
       end
       deprecate(:visit_safe, :visit_lax)
 
+      def visit_or_nil(node)
+        Types::OrNil.new(visit(node))
+      end
+
       def visit_nominal(node)
         type, meta = node
         nominal_name = "nominal.#{Types.identifier(type)}"

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -188,6 +188,15 @@ module Dry
         self
       end
 
+      # Return a type which checks the primitive, and returns nil if the check fails 
+      #
+      # @return [OrNil]
+      #
+      # @api public
+      def or_nil
+        constrained(type: primitive).or_nil
+      end
+
       # Wrap the type with a proc
       #
       # @return [Proc]

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -188,7 +188,7 @@ module Dry
         self
       end
 
-      # Return a type which checks the primitive, and returns nil if the check fails 
+      # Return a type which checks the primitive, and returns nil if the check fails
       #
       # @return [OrNil]
       #

--- a/lib/dry/types/or_nil.rb
+++ b/lib/dry/types/or_nil.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry/types/decorator'
+require "dry/types/decorator"
 
 module Dry
   module Types

--- a/lib/dry/types/or_nil.rb
+++ b/lib/dry/types/or_nil.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'dry/types/decorator'
+
+module Dry
+  module Types
+    # Lax types rescue from type-related errors when constructors fail and return nil
+    #
+    # @api public
+    class OrNil
+      include Type
+      include Decorator
+      include Builder
+      include Printable
+      include Dry::Equalizer(:type, inspect: false, immutable: true)
+
+      undef :options, :constructor, :<<, :>>, :prepend, :append
+
+      # @param [Object] input
+      #
+      # @return [Object]
+      #
+      # @api public
+      def call(input)
+        type.call_safe(input) { nil }
+      end
+      alias_method :[], :call
+      alias_method :call_safe, :call
+      alias_method :call_unsafe, :call
+
+      # @param [Object] input
+      # @param [#call,nil] block
+      #
+      # @yieldparam [Failure] failure
+      # @yieldreturn [Result]
+      #
+      # @return [Result,Logic::Result]
+      #
+      # @api public
+      def try(input, &block)
+        type.try(input, &block)
+      end
+
+      # @see Nominal#to_ast
+      #
+      # @api public
+      def to_ast(meta: true)
+        [:or_nil, type.to_ast(meta: meta)]
+      end
+
+      # @return [OrNix]
+      #
+      # @api public
+      def or_nil
+        self
+      end
+
+      private
+
+      # @param [Object, Dry::Types::Constructor] response
+      #
+      # @return [Boolean]
+      #
+      # @api private
+      def decorate?(response)
+        super || response.is_a?(type.constructor_type)
+      end
+    end
+  end
+end

--- a/lib/dry/types/or_nil.rb
+++ b/lib/dry/types/or_nil.rb
@@ -4,7 +4,7 @@ require "dry/types/decorator"
 
 module Dry
   module Types
-    # Lax types rescue from type-related errors when constructors fail and return nil
+    # OrNil types rescue from type-related errors when constructors fail and return nil
     #
     # @api public
     class OrNil

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -18,6 +18,7 @@ module Dry
         Array => :visit_array,
         Array::Member => :visit_array_member,
         Lax => :visit_lax,
+        OrNil => :visit_or_nil,
         Enum => :visit_enum,
         Default => :visit_default,
         Default::Callable => :visit_default,
@@ -229,6 +230,12 @@ module Dry
       def visit_lax(lax)
         visit(lax.type) do |type|
           yield "Lax<#{type}>"
+        end
+      end
+
+      def visit_or_nil(or_nil)
+        visit(or_nil.type) do |type|
+          yield "OrNil<#{type}>"
         end
       end
 

--- a/lib/dry/types/schema/key.rb
+++ b/lib/dry/types/schema/key.rb
@@ -103,6 +103,15 @@ module Dry
           __new__(type.lax).required(false)
         end
 
+        # Turn key into a or_nil type. OrNil types are not strict hence such keys are not required
+        #
+        # @return [OrNil]
+        #
+        # @api public
+        def or_nil
+          __new__(type.or_nil).required(false)
+        end
+
         # Make wrapped type optional
         #
         # @return [Key]

--- a/spec/dry/types/or_nil_spec.rb
+++ b/spec/dry/types/or_nil_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Types::Nominal, '#lax' do
+  context 'with a coercible string' do
+    subject(:type) { Dry::Types['coercible.string'].constrained(min_size: 5).or_nil }
+
+    it 'rescues from type-errors and returns nil' do
+      expect(type['pass']).to eql(nil)
+    end
+
+    it 'tries to apply its type' do
+      expect(type[:passing]).to eql('passing')
+    end
+
+    it 'aliases #[] as #call' do
+      expect(type.method(:call)).to eql(type.method(:[]))
+    end
+  end
+
+  context 'with a params hash' do
+    subject(:type) do
+      Dry::Types['params.hash'].schema(
+        age: 'coercible.integer', active: 'params.bool', name: Dry::Types['strict.string'].or_nil
+      ).or_nil
+    end
+
+    it 'applies its types' do
+      expect(type[age: '23', active: 'f', name: 'jon']).to eql(age: 23, active: false, name: 'jon')
+    end
+
+    it 'rescues from type-errors and returns nil' do
+      expect(type[age: 'wat', active: '1', name: 'jon']).to be_nil
+    end
+
+    it 'allows failures on the values and treats them as nil' do
+      expect(type[age: '23', active: 't', name: 123]).to eql(age: 23, active: true, name: nil)
+    end
+
+    it "doesn't decorate keys" do
+      expect(type.key(:age)).to be_a(Dry::Types::Schema::Key)
+      expect(type.key(:age).('23')).to eql(23)
+    end
+  end
+
+  context 'with an array' do
+    let(:source_type) { Dry::Types['array'].of(Dry::Types['coercible.integer']) }
+
+    subject(:type) { source_type.or_nil }
+
+    it 'rescues from type-errors and returns nil' do
+      expect(type[['1', :a, 30]]).to eql(nil)
+    end
+
+    it 'preserves meta' do
+      expect(source_type.meta(foo: :bar).or_nil.meta).to eql(foo: :bar)
+    end
+  end
+
+  context 'with an array member' do
+    let(:type) { Dry::Types['array'].of(Dry::Types['coercible.integer'].or_nil) }
+
+    it 'rescues from type-errors and returns nil' do
+      expect(type[['1', :a, 30]]).to eql([1, nil, 30])
+    end
+  end
+
+  context 'with a nominal' do
+    let(:type) { Dry::Types['nominal.integer'].or_nil }
+
+    it 'rescues from type-errors and returns nil' do
+      expect(type[:a]).to eql(nil)
+    end
+  end
+
+  context 'with a constructor type' do
+    let(:type) { Dry::Types['json.date_time'].or_nil }
+
+    it 'rescues from type-errors and returns nil' do
+      expect(type['abc']).to eql(nil)
+    end
+
+    it 'resolves properly to the underlying type' do
+      expect(type[Time.now.iso8601]).to respond_to(:iso8601)
+    end
+  end
+
+  describe '#to_s' do
+    subject(:type) { Dry::Types['nominal.integer'].or_nil }
+
+    it 'returns string representation of the type' do
+      expect(type.to_s).to eql("#<Dry::Types[OrNil<Constrained<Nominal<Integer> rule=[type?(Integer)]>>]>")
+    end
+  end
+
+  describe '#try' do
+    subject(:type) { Dry::Types['coercible.integer'].or_nil }
+
+    it 'delegates to underlying type' do
+      expect(type.try('1')).to be_a(Dry::Types::Result::Success)
+      expect(type.try('a')).to be_a(Dry::Types::Result::Failure)
+    end
+  end
+
+  describe '#or_nil' do
+    subject(:type) { Dry::Types['coercible.integer'].or_nil }
+
+    specify do
+      expect(type.or_nil).to be(type)
+    end
+  end
+end

--- a/spec/dry/types/or_nil_spec.rb
+++ b/spec/dry/types/or_nil_spec.rb
@@ -1,108 +1,108 @@
 # frozen_string_literal: true
 
-RSpec.describe Dry::Types::Nominal, '#lax' do
-  context 'with a coercible string' do
-    subject(:type) { Dry::Types['coercible.string'].constrained(min_size: 5).or_nil }
+RSpec.describe Dry::Types::Nominal, "#lax" do
+  context "with a coercible string" do
+    subject(:type) { Dry::Types["coercible.string"].constrained(min_size: 5).or_nil }
 
-    it 'rescues from type-errors and returns nil' do
-      expect(type['pass']).to eql(nil)
+    it "rescues from type-errors and returns nil" do
+      expect(type["pass"]).to eql(nil)
     end
 
-    it 'tries to apply its type' do
-      expect(type[:passing]).to eql('passing')
+    it "tries to apply its type" do
+      expect(type[:passing]).to eql("passing")
     end
 
-    it 'aliases #[] as #call' do
+    it "aliases #[] as #call" do
       expect(type.method(:call)).to eql(type.method(:[]))
     end
   end
 
-  context 'with a params hash' do
+  context "with a params hash" do
     subject(:type) do
-      Dry::Types['params.hash'].schema(
-        age: 'coercible.integer', active: 'params.bool', name: Dry::Types['strict.string'].or_nil
+      Dry::Types["params.hash"].schema(
+        age: "coercible.integer", active: "params.bool", name: Dry::Types["strict.string"].or_nil
       ).or_nil
     end
 
-    it 'applies its types' do
-      expect(type[age: '23', active: 'f', name: 'jon']).to eql(age: 23, active: false, name: 'jon')
+    it "applies its types" do
+      expect(type[age: "23", active: "f", name: "jon"]).to eql(age: 23, active: false, name: "jon")
     end
 
-    it 'rescues from type-errors and returns nil' do
-      expect(type[age: 'wat', active: '1', name: 'jon']).to be_nil
+    it "rescues from type-errors and returns nil" do
+      expect(type[age: "wat", active: "1", name: "jon"]).to be_nil
     end
 
-    it 'allows failures on the values and treats them as nil' do
-      expect(type[age: '23', active: 't', name: 123]).to eql(age: 23, active: true, name: nil)
+    it "allows failures on the values and treats them as nil" do
+      expect(type[age: "23", active: "t", name: 123]).to eql(age: 23, active: true, name: nil)
     end
 
     it "doesn't decorate keys" do
       expect(type.key(:age)).to be_a(Dry::Types::Schema::Key)
-      expect(type.key(:age).('23')).to eql(23)
+      expect(type.key(:age).("23")).to eql(23)
     end
   end
 
-  context 'with an array' do
-    let(:source_type) { Dry::Types['array'].of(Dry::Types['coercible.integer']) }
+  context "with an array" do
+    let(:source_type) { Dry::Types["array"].of(Dry::Types["coercible.integer"]) }
 
     subject(:type) { source_type.or_nil }
 
-    it 'rescues from type-errors and returns nil' do
-      expect(type[['1', :a, 30]]).to eql(nil)
+    it "rescues from type-errors and returns nil" do
+      expect(type[["1", :a, 30]]).to eql(nil)
     end
 
-    it 'preserves meta' do
+    it "preserves meta" do
       expect(source_type.meta(foo: :bar).or_nil.meta).to eql(foo: :bar)
     end
   end
 
-  context 'with an array member' do
-    let(:type) { Dry::Types['array'].of(Dry::Types['coercible.integer'].or_nil) }
+  context "with an array member" do
+    let(:type) { Dry::Types["array"].of(Dry::Types["coercible.integer"].or_nil) }
 
-    it 'rescues from type-errors and returns nil' do
-      expect(type[['1', :a, 30]]).to eql([1, nil, 30])
+    it "rescues from type-errors and returns nil" do
+      expect(type[["1", :a, 30]]).to eql([1, nil, 30])
     end
   end
 
-  context 'with a nominal' do
-    let(:type) { Dry::Types['nominal.integer'].or_nil }
+  context "with a nominal" do
+    let(:type) { Dry::Types["nominal.integer"].or_nil }
 
-    it 'rescues from type-errors and returns nil' do
+    it "rescues from type-errors and returns nil" do
       expect(type[:a]).to eql(nil)
     end
   end
 
-  context 'with a constructor type' do
-    let(:type) { Dry::Types['json.date_time'].or_nil }
+  context "with a constructor type" do
+    let(:type) { Dry::Types["json.date_time"].or_nil }
 
-    it 'rescues from type-errors and returns nil' do
-      expect(type['abc']).to eql(nil)
+    it "rescues from type-errors and returns nil" do
+      expect(type["abc"]).to eql(nil)
     end
 
-    it 'resolves properly to the underlying type' do
+    it "resolves properly to the underlying type" do
       expect(type[Time.now.iso8601]).to respond_to(:iso8601)
     end
   end
 
-  describe '#to_s' do
-    subject(:type) { Dry::Types['nominal.integer'].or_nil }
+  describe "#to_s" do
+    subject(:type) { Dry::Types["nominal.integer"].or_nil }
 
-    it 'returns string representation of the type' do
+    it "returns string representation of the type" do
       expect(type.to_s).to eql("#<Dry::Types[OrNil<Constrained<Nominal<Integer> rule=[type?(Integer)]>>]>")
     end
   end
 
-  describe '#try' do
-    subject(:type) { Dry::Types['coercible.integer'].or_nil }
+  describe "#try" do
+    subject(:type) { Dry::Types["coercible.integer"].or_nil }
 
-    it 'delegates to underlying type' do
-      expect(type.try('1')).to be_a(Dry::Types::Result::Success)
-      expect(type.try('a')).to be_a(Dry::Types::Result::Failure)
+    it "delegates to underlying type" do
+      expect(type.try("1")).to be_a(Dry::Types::Result::Success)
+      expect(type.try("a")).to be_a(Dry::Types::Result::Failure)
     end
   end
 
-  describe '#or_nil' do
-    subject(:type) { Dry::Types['coercible.integer'].or_nil }
+  describe "#or_nil" do
+    subject(:type) { Dry::Types["coercible.integer"].or_nil }
 
     specify do
       expect(type.or_nil).to be(type)


### PR DESCRIPTION
So there have been a few times where it would be nice to simply nullify a value if a type is invalid. Imagine we have this type:

```ruby
EmailAddress ||= begin
  Types::String
    .constructor(&:downcase)
    .constructor(&:strip)
    .constrained(format: URI::MailTo::EMAIL_REGEXP)
end
```

Currently, you can use `.lax` to rescue and return the input: `EmailAddress.lax.call('bad') #=> 'bad'`

This is useful, but it would useful to be able to nil out the value, as well. This would make it much easier to filter our junky data that’s is not business critical.

This PR adds `#or_nil` to support this exact use case

```ruby
EmailAddress.or_nil.call('test@test.com') #=> 'test@test.com'`
EmailAddress.or_nil.call('bad') #=> nil`
```

via: https://discourse.dry-rb.org/t/something-like-lax-but-return-nil-instead-of-input/1168/2