### PR TITLE
Wrapping constructor types

### DIFF
--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -127,7 +127,7 @@ module Dry
       #
       # @api public
       def constructor(constructor = nil, **options, &block)
-        constructor_type.new(with(**options), fn: constructor || block)
+        constructor_type[with(**options), fn: constructor || block]
       end
       alias_method :append, :constructor
       alias_method :prepend, :constructor

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -29,11 +29,9 @@ module Dry
         @rule = options.fetch(:rule)
       end
 
-      # @api private
-      #
       # @return [Object]
       #
-      # @api public
+      # @api private
       def call_unsafe(input)
         result = rule.(input)
 
@@ -44,11 +42,9 @@ module Dry
         end
       end
 
-      # @api private
-      #
       # @return [Object]
       #
-      # @api public
+      # @api private
       def call_safe(input, &block)
         if rule[input]
           type.call_safe(input, &block)

--- a/lib/dry/types/constructor/wrapper.rb
+++ b/lib/dry/types/constructor/wrapper.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Dry
+  module Types
+    # @api public
+    class Constructor < Nominal
+      module Wrapper
+        # @return [Object]
+        #
+        # @api private
+        def call_safe(input, &block)
+          fn.(input, type, &block)
+        end
+
+        # @return [Object]
+        #
+        # @api private
+        def call_unsafe(input)
+          fn.(input, type)
+        end
+
+        # @param [Object] input
+        # @param [#call,nil] block
+        #
+        # @return [Logic::Result, Types::Result]
+        # @return [Object] if block given and try fails
+        #
+        # @api public
+        def try(input, &block)
+          value = fn.(input, type)
+        rescue CoercionError => e
+          failure = failure(input, e)
+          block_given? ? yield(failure) : failure
+        else
+          type.try(value, &block)
+        end
+
+        # Define a constructor for the type
+        #
+        # @param [#call,nil] constructor
+        # @param [Hash] options
+        # @param [#call,nil] block
+        #
+        # @return [Constructor]
+        #
+        # @api public
+        define_method(:constructor, Builder.instance_method(:constructor))
+        alias_method :append, :constructor
+        alias_method :>>, :constructor
+
+        # Build a new constructor by prepending a block to the coercion function
+        #
+        # @param [#call, nil] new_fn
+        # @param [Hash] options
+        # @param [#call, nil] block
+        #
+        # @return [Constructor]
+        #
+        # @api public
+        def prepend(new_fn = nil, **options, &block)
+          prep_fn = Function[new_fn || block]
+
+          decorated =
+            if prep_fn.wrapper?
+              type.constructor(prep_fn, **options)
+            else
+              type.prepend(prep_fn, **options)
+            end
+
+          __new__(decorated)
+        end
+        alias_method :<<, :prepend
+
+        # @return [Constructor]
+        #
+        # @api public
+        def lax
+          # return self back because wrapping function
+          # can handle failed type check
+          self
+        end
+
+        private
+
+        # Replace underlying type
+        #
+        # @api private
+        def __new__(type)
+          self.class.new(type, *@__args__.drop(1), **@options)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/types/decorator.rb
+++ b/lib/dry/types/decorator.rb
@@ -100,7 +100,7 @@ module Dry
       #
       # @api private
       def __new__(type)
-        self.class.new(type, *@__args__[1..-1], **@options)
+        self.class.new(type, *@__args__.drop(1), **@options)
       end
     end
   end

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -7,8 +7,6 @@ module Dry
       MAPPING = {
         Nominal => :visit_nominal,
         Constructor => :visit_constructor,
-        Hash::Constructor => :visit_constructor,
-        Array::Constructor => :visit_constructor,
         Constrained => :visit_constrained,
         Constrained::Coercible => :visit_constrained,
         Hash => :visit_hash,
@@ -34,7 +32,9 @@ module Dry
 
       def visit(type, &block)
         print_with = MAPPING.fetch(type.class) do
-          if type.is_a?(Type)
+          if type.class < Constructor
+            :visit_constructor
+          elsif type.is_a?(Type)
             return yield type.inspect
           else
             raise ArgumentError, "Do not know how to print #{type.class}"

--- a/lib/dry/types/spec/types.rb
+++ b/lib/dry/types/spec/types.rb
@@ -127,6 +127,18 @@ RSpec.shared_examples_for 'a constrained type' do |options = { inputs: Object.ne
       end
     end
   end
+
+  describe "#constructor" do
+    let(:wrapping_constructor) do
+      type.constructor { |input, type| type.(input) { fallback } }
+    end
+
+    it "can be wrapped" do
+      Array(inputs).each do |input|
+        expect(wrapping_constructor.(input)).to be(fallback)
+      end
+    end
+  end
 end
 
 RSpec.shared_examples_for 'a nominal type' do |inputs: Object.new|

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -363,5 +363,20 @@ RSpec.describe Dry::Types::Compiler, '#call' do
       expect(type).to eql(source)
       expect(type.('1')).to eql(1)
     end
+
+    example "wrapping constructor" do
+      fn = lambda do |input, type, &block|
+        300 + type.("#{input}0", &block)
+      end
+
+      source = Dry::Types["coercible.integer"].constructor(fn)
+
+      ast = source.to_ast
+
+      type = compiler.(ast)
+
+      expect(type['123']).to eql(1530)
+      expect(type).to eql(source)
+    end
   end
 end

--- a/spec/dry/types/constrained_spec.rb
+++ b/spec/dry/types/constrained_spec.rb
@@ -116,6 +116,24 @@ RSpec.describe Dry::Types::Constrained do
     end
   end
 
+  context 'with a wrapping constructor' do
+    subject(:type) do
+      Dry::Types['coercible.integer'].constructor { |input, t|
+        t.(input + '0') + 10
+      }.constrained(gt: 300)
+    end
+
+    example 'success' do
+      expect(type.('30')).to eql(310)
+      expect(type.valid?('30')).to be(true)
+    end
+
+    example 'failure' do
+      expect(type.('20') { :fallback }).to eql(:fallback)
+      expect(type.valid?('20')).to be(false)
+    end
+  end
+
   context 'with an optional sum type' do
     subject(:type) do
       Dry::Types['nominal.string'].constrained(size: 4).optional

--- a/spec/dry/types/constructor/wrapper_spec.rb
+++ b/spec/dry/types/constructor/wrapper_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "dry/types/constructor"
+
+RSpec.describe Dry::Types::Constructor.wrapper_type do
+  let(:int) { Dry::Types["coercible.integer"] }
+
+  let(:constructor_block) do
+    lambda do |input, type, &block|
+      300 + type.("#{input}0", &block)
+    end
+  end
+
+  let(:type) { int.constructor(constructor_block) }
+
+  describe "#valid?" do
+    specify do
+      expect(type.valid?("123")).to be(true)
+      expect(type.valid?("abc")).to be(false)
+    end
+  end
+
+  describe "#try" do
+    specify do
+      expect(type.try("123")).to be_success
+      expect(type.try("abc")).to be_failure
+    end
+  end
+
+  describe "#lax" do
+    let(:type) { super().lax }
+
+    it "keeps underlying type not laxed since we have control over the whole construction" do
+      expect(type.("abc") { :fallback }).to eql(:fallback)
+    end
+  end
+
+  describe "#meta" do
+    let(:type) { super().meta(foo: 1) }
+
+    it "preserves type" do
+      expect(type).to be_a(described_class)
+      expect(type.valid?("123")).to be(true)
+    end
+  end
+
+  describe "#call" do
+    context "successful coercion" do
+      specify do
+        expect(type.("123")).to eql(1530)
+      end
+
+      context "constrained type" do
+        let(:type) { super().constrained(gt: 300) }
+
+        specify do
+          expect(type.("123")).to eql(1530)
+        end
+      end
+    end
+
+    context "unsuccessful coercion with fallback" do
+      specify do
+        expect(type.("abc") { :fallback }).to eql(:fallback)
+      end
+    end
+  end
+
+  describe "builder methods" do
+    describe "#prepend" do
+      context "ordinary" do
+        let(:type) { super().prepend { |input| "#{input}22" } }
+
+        it "adds a prepdending constructor" do
+          # 123 -> 1230 -> 123022 -> 123322
+          expect(type.("123")).to eql(123_322)
+        end
+      end
+
+      context "wrapping" do
+        let(:type) do
+          super().prepend { |input, type| type.("7#{input}") + 40 }
+        end
+
+        it "adds a prepdending constructor" do
+          # 123 -> 1230 -> 71230 -> 71270 -> 71570
+          expect(type.("123")).to eql(71_570)
+        end
+      end
+    end
+
+    describe "#append" do
+      let(:type) { super().append { |input| "#{input}22" } }
+
+      specify do
+        # 123 -> 12322 -> 123220 -> 123520
+        expect(type.("123")).to eql(123_520)
+      end
+    end
+
+    describe "#constructor" do
+      context "wrapping" do
+        let(:type) { super().constructor(constructor_block) }
+
+        it "chains wrappers" do
+          expect(type.("123")).to eql(12_900)
+        end
+      end
+    end
+
+    describe "#constrained" do
+      let(:type) { super().constrained(gt: 10_000) }
+
+      it "raises an error on invalid input" do
+        expect { type.("1") }.to raise_error(Dry::Types::ConstraintError)
+      end
+
+      it "accepts valid input" do
+        expect(type.("1000")).to eql(10_300)
+      end
+    end
+  end
+end

--- a/spec/dry/types/lax_spec.rb
+++ b/spec/dry/types/lax_spec.rb
@@ -40,6 +40,22 @@ RSpec.describe Dry::Types::Nominal, '#lax' do
       expect(type.key(:age)).to be_a(Dry::Types::Schema::Key)
       expect(type.key(:age).('23')).to eql(23)
     end
+
+    context "wrapping constructors" do
+      let(:age) do
+        Dry::Types["coercible.integer"].constructor do |input, type|
+          type.(input) + 1
+        end
+      end
+
+      subject(:type) do
+        Dry::Types["params.hash"].schema(age: age, active: "params.bool").lax
+      end
+
+      it "applies its types" do
+        expect(type[age: "23", active: "f"]).to eql(age: 24, active: false)
+      end
+    end
   end
 
   context 'with an array' do

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'dry-struct'
-require 'spec_helper'
+require 'dry/struct'
 
 RSpec.describe Dry::Types::Module do
   let(:registry) { Dry::Types.container }

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Dry::Types, '#to_ast' do
   let(:fn) { Kernel.method(:String) }
 


### PR DESCRIPTION
This adds support for constructor types that can hook into "type application" by taking control when the block has two parameters:
```ruby
# This type parses input integer value and then adds 1 to the result
Month = Dry::Types["coercible.integer"].constructor do |input, type|
  type.(input) + 1
end
```
Earlier, this could be done with just `.constructor { |input| + 1 }`, however, having control over `type` allows for implementing various fallback strategies:
```ruby
Age = Dry::Types["coercible.integer"].constructor do |input, type|
  type.(input) { 18 }
end
Age.('17') # => 17
Age.('foo') # => 18
```
These kinds of constructor blocks also support `prepending` and `appending`. Generally, this interface is akin to the rack's middleware.

A word of warning: constructor types can get tricky, this is especially true for wrapping constructors. For instance, calling `.lax` on such a type would be a no-op since it's assumed you handle failing cases manually (it's actually required for the use case in dry-schema).