### PR TITLE
Types with fallback values

### DIFF
--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -17,6 +17,11 @@ module Dry
         def evaluate
           value.call(type)
         end
+
+        # @return [true]
+        def callable?
+          true
+        end
       end
 
       include Type
@@ -110,6 +115,13 @@ module Dry
         else
           Undefined.default(type.call_safe(input, &block)) { evaluate }
         end
+      end
+
+      # @return [false]
+      #
+      # @api private
+      def callable?
+        false
       end
     end
   end

--- a/spec/dry/types/builder_spec.rb
+++ b/spec/dry/types/builder_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "dry/types/builder"
+
+RSpec.describe Dry::Types::Builder do
+  let(:base) { Dry::Types["string"].constrained(min_size: 4) }
+
+  describe "#fallback" do
+    context "using block" do
+      subject(:type) { base.fallback { "fallback" } }
+
+      it "returns block result on invalid input" do
+        expect(type.("123")).to eql("fallback")
+        expect(type.("long")).to eql("long")
+      end
+
+      it "is not possible to provide a different fallback" do
+        expect(type.("123") { raise }).to eql("fallback")
+        expect(type.("long") { raise }).to eql("long")
+      end
+
+      context "fallback for a lax type" do
+        subject(:type) { base.lax.fallback { "fallback" } }
+
+        it "is not used" do
+          expect(type.("123")).to eql("123")
+        end
+      end
+
+      context "lax type after fallback" do
+        subject(:type) { base.fallback { "fallback" }.lax }
+
+        it "is used" do
+          expect(type.("123")).to eql("fallback")
+        end
+      end
+
+      context "complex type" do
+        subject(:type) do
+          Dry::Types["array"].of(
+            Dry::Types["params.hash"].schema(
+              name: "string",
+              age: "params.integer",
+              email: Dry::Types["string"].constrained(format: /@/)
+            ).optional.fallback(nil)
+          ).constructor { |input, type| type.(input) { [] }.compact }
+        end
+
+        let(:john_input) do
+          { name: "John", age: "20", email: "john@doe.com" }
+        end
+
+        let(:john_output) do
+          { name: "John", age: 20, email: "john@doe.com" }
+        end
+
+        example "working complex type" do
+          expect(type.(nil)).to eql([])
+          expect(type.([])).to eql([])
+          expect(type.([nil])).to eql([])
+          expect(type.([{}])).to eql([])
+          expect(type.([john_input])).to eql([john_output])
+          expect(type.([john_input, { name: "Jane", age: "22" }])).to eql([john_output])
+        end
+      end
+    end
+
+    context "using value" do
+      subject(:type) { base.fallback("fallback") }
+
+      it "returns block result on invalid input" do
+        expect(type.("123")).to eql("fallback")
+        expect(type.("long")).to eql("long")
+      end
+
+      it "is not possible to provide a different fallback" do
+        expect(type.("123") { raise }).to eql("fallback")
+        expect(type.("long") { raise }).to eql("long")
+      end
+
+      it "prints warning when default value isn't frozen" do
+        expect(Dry::Core::Deprecations).to receive(:warn)
+        base.fallback("foobar".dup)
+      end
+
+      it "doesn't print warning when default value isn't frozen with an option given" do
+        expect(Dry::Core::Deprecations).not_to receive(:warn)
+        base.fallback("foobar".dup, shared: true)
+      end
+    end
+
+    context "providing no arguments" do
+      it "raises an error" do
+        expect { base.fallback }.to raise_error(
+          ArgumentError, /fallback value or a block must be given/
+        )
+      end
+    end
+
+    context "providing invalid value" do
+      it "gets rejected" do
+        expect { base.fallback(123) }.to raise_error(
+          Dry::Types::ConstraintError,
+          /violates constraints/
+        )
+      end
+    end
+  end
+end

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Dry::Types::Builder, '#default' do
 
       it_behaves_like 'Dry::Types::Nominal without primitive'
 
-      it 'allows nil' do
+      specify do
         expect(type[]).to eq({})
       end
     end
@@ -55,7 +55,7 @@ RSpec.describe Dry::Types::Builder, '#default' do
 
       it_behaves_like 'Dry::Types::Nominal without primitive'
 
-      it 'allows nil' do
+      specify do
         expect(type[]).to eq({})
       end
     end

--- a/spec/dry/types/lax_spec.rb
+++ b/spec/dry/types/lax_spec.rb
@@ -42,18 +42,30 @@ RSpec.describe Dry::Types::Nominal, '#lax' do
     end
 
     context "wrapping constructors" do
-      let(:age) do
-        Dry::Types["coercible.integer"].constructor do |input, type|
-          type.(input) + 1
+      subject(:type) do
+        Dry::Types["hash"].schema(age: age, active: "params.bool").lax
+      end
+
+      context "modification" do
+        let(:age) do
+          Dry::Types["coercible.integer"].constructor do |input, type|
+            type.(input) + 1
+          end
+        end
+
+        it "applies its types" do
+          expect(type[age: "23", active: "f"]).to eql(age: 24, active: false)
         end
       end
 
-      subject(:type) do
-        Dry::Types["params.hash"].schema(age: age, active: "params.bool").lax
-      end
+      context "fallback" do
+        let(:age) do
+          Dry::Types["integer"].constrained(gteq: 18).fallback(18).meta(foo: :bar)
+        end
 
-      it "applies its types" do
-        expect(type[age: "23", active: "f"]).to eql(age: 24, active: false)
+        it "applies its types" do
+          expect(type[age: "aa", active: "f"]).to eql(age: 18, active: false)
+        end
       end
     end
   end


### PR DESCRIPTION
This adds the `.fallback` method that wraps a type with a fallback value or a block. It's different from `.default` since default types make sense only for missing/absent values (e.g. missing keys in schema input). `.fallback` is more general:

```ruby
age = Types::Integer.fallback(18)
age.(20) # => 20
age.("invalid") # => 18
```

In some cases, `.default` and `.fallback` can be used interchangeably but I advise against this since it doesn't always use as you would expect:
```ruby
age.() # => 18
Types::Hash.schema(age: age).({}) # => :age is missing in Hash input
```

Fallbacks are tested to be compatible with dry-schema, see https://github.com/dry-rb/dry-schema/pull/337/files#diff-753532781c2792be1bada750fdaca7f5f8bca2ac6021da8afea8916ae3a02f86

Under the hood, it uses wrapping constructors [added earlier](https://github.com/dry-rb/dry-types/pull/410) so it just utilizes an existing mechanism.