### PR TITLE
Add params.string

### DIFF
--- a/lib/dry/types/params.rb
+++ b/lib/dry/types/params.rb
@@ -56,6 +56,8 @@ module Dry
       self["nominal.symbol"].constructor(Coercions::Params.method(:to_symbol))
     end
 
+    register("params.string", self["string"])
+
     COERCIBLE.each_key do |name|
       next if name.equal?(:string)
 

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -250,6 +250,14 @@ RSpec.describe Dry::Types::Nominal do
     end
   end
 
+  describe "params.string" do
+    subject(:type) { Dry::Types["params.string"] }
+
+    it "is equal to strict.string" do
+      expect(type).to be(Dry::Types["string"])
+    end
+  end
+
   context "optional types" do
     subject(:type) { Dry::Types["optional.params.integer"] }
 


### PR DESCRIPTION
Logically, it's no different from strict.string. It seems like dry-schema is fine with the change, I'll do a few more tests, though.