### PR TITLE
Add :builders extension with custom type constructors

### DIFF
--- a/lib/dry/types/extensions.rb
+++ b/lib/dry/types/extensions.rb
@@ -7,3 +7,7 @@ end
 Dry::Types.register_extension(:monads) do
   require "dry/types/extensions/monads"
 end
+
+Dry::Types.register_extension(:builders) do
+  require "dry/types/extensions/builders"
+end

--- a/lib/dry/types/extensions/builders.rb
+++ b/lib/dry/types/extensions/builders.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Dry
+  module Types
+    module Builder
+      # Build a type that returns `nil` on invalid input
+      #
+      # @return [Constructor]
+      #
+      # @api public
+      def or_nil
+        optional.fallback(nil)
+      end
+    end
+  end
+end

--- a/spec/extensions/builders_spec.rb
+++ b/spec/extensions/builders_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Types::Builder do
+  before(:all) { Dry::Types.load_extensions(:builders) }
+
+  let(:base) { Dry::Types["string"].constrained(min_size: 4) }
+
+  describe "#or_nil" do
+    let(:type) { base.or_nil }
+
+    it "returns nil on invalid input" do
+      expect(type.("123")).to be_nil
+      expect(type.("long")).to eql("long")
+    end
+
+    specify do
+      expect(type).to be_optional
+    end
+  end
+end


### PR DESCRIPTION
This kinda extends our API and we could use, say, refinements instead. But as far as I can see it should be safe. @solnic @timriley @ianks thoughts?

Alternatively, we could add an API for registering custom constructors:
```ruby
Dry::Types.load_extensions(:builders)
Dry::Types.define_builder(:or_nil) { |type| type.optional.fallback(nil) } 
```

ref #409