### PR TITLE
Support for custom builder methods

### DIFF
--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -42,7 +42,7 @@ module Dry
       #
       # @api public
       def optional
-        Types["strict.nil"] | self
+        Types["nil"] | self
       end
 
       # Turn a type into a constrained type

--- a/spec/dry/types_spec.rb
+++ b/spec/dry/types_spec.rb
@@ -57,4 +57,20 @@ RSpec.describe Dry::Types do
       }.to raise_error(NameError, /dry-types does not define constants for default types/)
     end
   end
+
+  describe ".define_builder" do
+    it "adds a new builder method" do
+      Dry::Types.define_builder(:or_nil) { |type| type.optional.fallback(nil) }
+      constructed = Dry::Types["integer"].or_nil
+
+      expect(constructed.("123")).to be_nil
+    end
+
+    it "has support for arguments" do
+      Dry::Types.define_builder(:or) { |type, fallback| type.fallback(fallback) }
+      constructed = Dry::Types["integer"].or(300)
+
+      expect(constructed.("123")).to eql(300)
+    end
+  end
 end


### PR DESCRIPTION
Given we have a stable and flexible API for building types I think it's relatively safe to give users a way to define custom type constructors. An even "safer" way would be using refinements but it doesn't look it's worth it.

ref #413, #409