### PR TITLE
Add missing dry/core/equalizer requires

### DIFF
--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
 require "dry/types/decorator"
 require "dry/types/constraints"
 require "dry/types/constrained/coercible"

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
 require "dry/types/fn_container"
 require "dry/types/constructor/function"
 require "dry/types/constructor/wrapper"

--- a/lib/dry/types/constructor/function.rb
+++ b/lib/dry/types/constructor/function.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
 require "concurrent/map"
 
 module Dry

--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
 require "dry/types/decorator"
 
 module Dry

--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
 require "dry/types/decorator"
 
 module Dry

--- a/lib/dry/types/extensions/maybe.rb
+++ b/lib/dry/types/extensions/maybe.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
 require "dry/monads/maybe"
 require "dry/types/decorator"
 

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/core/deprecations"
+require "dry/core/equalizer"
 require "dry/types/builder"
 require "dry/types/result"
 require "dry/types/options"

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "dry/core/equalizer"
 require "dry/types/options"
 require "dry/types/meta"
 


### PR DESCRIPTION
Putting these in any file where we refer to Dry::Equalizer should prevent `undefined method 'Equalizer' for Dry:Module` occurring, regardless of the order of requires.

@solnic @flash-gordon Is there any reason these weren't here before? We get the error above today in CI when upgrading a work project to 1.5.0.