### PR TITLE
Optimize PredicateRegistry for Ruby 2.7+

### DIFF
--- a/lib/dry/types/predicate_registry.rb
+++ b/lib/dry/types/predicate_registry.rb
@@ -14,20 +14,35 @@ module Dry
       # @api private
       attr_reader :has_predicate
 
-      # @api private
-      def initialize(predicates = Logic::Predicates)
-        @predicates = predicates
-        @has_predicate = ::Kernel.instance_method(:respond_to?).bind(@predicates)
+      KERNEL_RESPOND_TO = ::Kernel.instance_method(:respond_to?)
+      private_constant(:KERNEL_RESPOND_TO)
+
+      if ::UnboundMethod.method_defined?(:bind_call)
+        # @api private
+        def initialize(predicates = Logic::Predicates)
+          @predicates = predicates
+        end
+
+        # @api private
+        def key?(name)
+          KERNEL_RESPOND_TO.bind_call(@predicates, name)
+        end
+      else
+        # @api private
+        def initialize(predicates = Logic::Predicates)
+          @predicates = predicates
+          @has_predicate = KERNEL_RESPOND_TO.bind(@predicates)
+        end
+
+        # @api private
+        def key?(name)
+          has_predicate.(name)
+        end
       end
 
       # @api private
       def [](name)
         predicates[name]
-      end
-
-      # @api private
-      def key?(name)
-        has_predicate.(name)
       end
     end
   end


### PR DESCRIPTION
2.7 introduced `UnboundMethod#bind_call` which is much faster than
doing `Method.bind(receiver).call`.

And even on older rubies caching `Kernel.instance_method(:respond_to?)`
in a constant will save quite a lot of extra costly allocations.