### PR TITLE
Add missing test for a default with Undefined

### DIFF
--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Dry::Types::Builder, "#default" do
       expect(type[]).to eql("foo")
     end
 
+    it "returns default value when Undefined is passed" do
+      expect(type[Undefined]).to eql("foo")
+    end
+
     it "aliases #[] as #call" do
       expect(type.call).to eql("foo")
     end


### PR DESCRIPTION
When Dry::Core::Constants::Undefined is given to a type with default,
the default value is returned. The test for this behavior was missing.