### PR TITLE
Implement SchemaError#value and SchemaError#key

### DIFF
--- a/lib/dry/types/errors.rb
+++ b/lib/dry/types/errors.rb
@@ -67,10 +67,18 @@ module Dry
     end
 
     class SchemaError < CoercionError
+      # @return [String, Symbol]
+      attr_reader :key
+
+      # @return [Object]
+      attr_reader :value
+
       # @param [String,Symbol] key
       # @param [Object] value
       # @param [String, #to_s] result
       def initialize(key, value, result)
+        @key = key
+        @value = value
         super(
           "#{value.inspect} (#{value.class}) has invalid type "\
           "for :#{key} violates constraints (#{result} failed)"

--- a/spec/dry/types/schema_spec.rb
+++ b/spec/dry/types/schema_spec.rb
@@ -267,9 +267,12 @@ RSpec.describe Dry::Types::Schema do
       expect {
         hash.call(name: :Jane, age: "oops", active: true, phone: [])
       }.to raise_error(
-        Dry::Types::SchemaError,
-        '"oops" (String) has invalid type for :age violates '\
-        'constraints (type?(Integer, "oops") failed)'
+        an_instance_of(Dry::Types::SchemaError).and(having_attributes(
+                                                      message: '"oops" (String) has invalid type for :age violates '\
+                                                        'constraints (type?(Integer, "oops") failed)',
+                                                      key: :age,
+                                                      value: "oops"
+                                                    ))
       )
     end
 
@@ -277,9 +280,12 @@ RSpec.describe Dry::Types::Schema do
       expect {
         hash.schema(age: "coercible.integer").call(name: :Jane, age: nil, active: true, phone: [])
       }.to raise_error(
-        Dry::Types::SchemaError,
-        "nil (NilClass) has invalid type for :age violates constraints"\
-        " (can't convert nil into Integer failed)"
+        an_instance_of(Dry::Types::SchemaError).and(having_attributes(
+                                                      message: "nil (NilClass) has invalid type for :age violates constraints"\
+                                                      " (can't convert nil into Integer failed)",
+                                                      key: :age,
+                                                      value: nil
+                                                    ))
       )
     end
 
@@ -287,9 +293,12 @@ RSpec.describe Dry::Types::Schema do
       expect {
         hash.schema(age: "coercible.integer").call(name: :Jane, age: "oops", active: true, phone: [])
       }.to raise_error(
-        Dry::Types::SchemaError,
-        '"oops" (String) has invalid type for :age violates constraints'\
-        ' (invalid value for Integer(): "oops" failed)'
+        an_instance_of(Dry::Types::SchemaError).and(having_attributes(
+                                                      message: '"oops" (String) has invalid type for :age violates constraints'\
+                                                      ' (invalid value for Integer(): "oops" failed)',
+                                                      key: :age,
+                                                      value: "oops"
+                                                    ))
       )
     end
 


### PR DESCRIPTION
This PR implements `SchemaError#key` & `SchemaError#value`. It makes `SchemaError`s interface more in line with `MissingKeyError`, `UnknownKeysError` & `ConstraintError` which have (most) of their instance variables accessible to the public.