### PR TITLE
Update example to use new Dry.Types() syntax

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -28,7 +28,7 @@ require 'dry-types'
 require 'dry-struct'
 
 module Types
-  include Dry::Types.module
+  include Dry.Types()
 end
 
 class User < Dry::Struct


### PR DESCRIPTION
Tiny docs change, just ran into a deprecation error when attempting to use the example code.