### PR TITLE
Zeitwerk fixes

### DIFF
--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -36,6 +36,8 @@ module Dry
         loader.push_dir(root)
         loader.ignore(
           "#{root}/dry-types.rb",
+          "#{root}/dry/types/extensions",
+          "#{root}/dry/types/spec/types.rb",
           "#{root}/dry/types/{#{%w[
             compat
             constraints

--- a/lib/dry/types.rb
+++ b/lib/dry/types.rb
@@ -37,6 +37,7 @@ module Dry
         loader.ignore(
           "#{root}/dry-types.rb",
           "#{root}/dry/types/{#{%w[
+            compat
             constraints
             core
             errors

--- a/spec/dry/types_spec.rb
+++ b/spec/dry/types_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Dry::Types do
+  describe ".loader" do
+    it "can eagerly load this library" do
+      Dry::Types.loader.eager_load
+    ensure
+      Dry::Types.loader.unload
+    end
+  end
+
   describe ".register" do
     it "registers a new type constructor" do
       module Test


### PR DESCRIPTION
When using `Dry::Types.loader.eager_load`, Zeitwerk raises more than one error:

```
Zeitwerk::NameError:
  expected file .../dry-types/lib/dry/types/compat.rb to define constant Dry::Types::Compat, but didn't

NameError: uninitialized constant Dry::Types::Extensions
  .../dry-core/lib/dry/core/deprecations.rb:227:in `block (2 levels) in deprecate_constant'

NameError: uninitialized constant RSpec
  from .../dry-types/lib/dry/types/spec/types.rb:3:in `<top (required)>'
```

Add some ignores to prevent this error; add a test that ensures eager loading works.