### PR TITLE
Add support for ranges

### DIFF
--- a/docsite/source/built-in-types.html.md
+++ b/docsite/source/built-in-types.html.md
@@ -34,6 +34,7 @@ Assuming you included `Dry::Types` ([see instructions](docs::getting-started)) i
   - `Types::Nominal::Time`
   - `Types::Nominal::Array`
   - `Types::Nominal::Hash`
+  - `Types::Nominal::Range`
 
 * `Strict` types will raise an error if passed a value of the wrong type:
   - `Types::Strict::Nil`
@@ -51,6 +52,7 @@ Assuming you included `Dry::Types` ([see instructions](docs::getting-started)) i
   - `Types::Strict::Time`
   - `Types::Strict::Array`
   - `Types::Strict::Hash`
+  - `Types::Strict::Range`
 
 > All types in the `strict` category are [constrained](docs::constraints) by a type-check that is applied to make sure that the input is an instance of the primitive:
 
@@ -67,6 +69,7 @@ Types::Strict::Integer['1'] # => raises Dry::Types::ConstraintError
   - `Types::Coercible::Decimal`
   - `Types::Coercible::Array`
   - `Types::Coercible::Hash`
+  - `Types::Coercible::Range`
 
 * Types suitable for `Params` param processing with coercions:
   - `Types::Params::Nil`
@@ -81,6 +84,7 @@ Types::Strict::Integer['1'] # => raises Dry::Types::ConstraintError
   - `Types::Params::Decimal`
   - `Types::Params::Array`
   - `Types::Params::Hash`
+  - `Types::Params::Range`
 
 * Types suitable for `JSON` processing with coercions:
   - `Types::JSON::Nil`
@@ -91,6 +95,7 @@ Types::Strict::Integer['1'] # => raises Dry::Types::ConstraintError
   - `Types::JSON::Decimal`
   - `Types::JSON::Array`
   - `Types::JSON::Hash`
+  - `Types::JSON::Range`
 
 * `Maybe` strict types:
   - `Types::Maybe::Strict::Class`
@@ -106,6 +111,7 @@ Types::Strict::Integer['1'] # => raises Dry::Types::ConstraintError
   - `Types::Maybe::Strict::Time`
   - `Types::Maybe::Strict::Array`
   - `Types::Maybe::Strict::Hash`
+  - `Types::Maybe::Strict::Range`
 
 * `Maybe` coercible types:
   - `Types::Maybe::Coercible::String`
@@ -114,5 +120,6 @@ Types::Strict::Integer['1'] # => raises Dry::Types::ConstraintError
   - `Types::Maybe::Coercible::Decimal`
   - `Types::Maybe::Coercible::Array`
   - `Types::Maybe::Coercible::Hash`
+  - `Types::Maybe::Coercible::Range`
 
 > `Maybe` types are not available by default - they must be loaded using `Dry::Types.load_extensions(:maybe)`. See [Maybe extension](docs::extensions/maybe) for more information.

--- a/docsite/source/custom-types.html.md
+++ b/docsite/source/custom-types.html.md
@@ -86,6 +86,14 @@ Types.Hash(name: Types::String, age: Types::Coercible::Integer)
 ListOfStrings = Types.Array(Types::String)
 ```
 
+### `Types.Range`
+
+`Types.Range` is a shortcut for `Types::Range.of`
+
+```ruby
+RangeOfIntegers = Types.Range(Types::Integer)
+```
+
 ### `Types.Interface`
 
 `Types.Interface` builds a type that checks a value responds to given methods.

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -13,6 +13,7 @@ sections:
   - constraints
   - hash-schemas
   - array-with-member
+  - range-with-member
   - enum
   - map
   - custom-types
@@ -133,6 +134,7 @@ Types::Strict::String[10000]
 * Support for [enums](docs::enum)
 * Support for [hash type with type schemas](docs::hash-schemas)
 * Support for [array type with members](docs::array-with-member)
+* Support for [range type with members](docs::range-with-member)
 * Support for arbitrary meta information
 * Support for typed struct objects via [dry-struct](/gems/dry-struct)
 * Types are [categorized](docs::built-in-types), which is especially important for optimized and dedicated coercion logic

--- a/docsite/source/range-with-member.html.md
+++ b/docsite/source/range-with-member.html.md
@@ -1,0 +1,13 @@
+---
+title: Range With Member
+layout: gem-single
+name: dry-types
+---
+
+The built-in range type supports defining the member's type:
+
+``` ruby
+IntegerRange = Types::Range.of(Types::Coercible::Integer)
+
+IntegerRange[1.0..2.0] # 1..2
+```

--- a/lib/dry/types/builder_methods.rb
+++ b/lib/dry/types/builder_methods.rb
@@ -36,6 +36,20 @@ module Dry
         Strict(::Hash).schema(type_map)
       end
 
+      # Build an range type.
+      #
+      # Shortcut for Range#of.
+      #
+      # @example
+      #   Types::IntegerRange = Types.Range(Types::Integer)
+      #
+      # @param [Dry::Types::Type] type
+      #
+      # @return [Dry::Types::Range]
+      def Range(type)
+        Strict(::Range).of(type)
+      end
+
       # Build a type which values are instances of a given class
       # Values are checked using `is_a?` call
       #
@@ -102,6 +116,8 @@ module Dry
           Array.new(klass)
         elsif klass <= ::Hash
           Hash.new(klass)
+        elsif klass <= ::Range
+          Range.new(klass)
         else
           Nominal.new(klass)
         end

--- a/lib/dry/types/coercions/params.rb
+++ b/lib/dry/types/coercions/params.rb
@@ -162,6 +162,25 @@ module Dry
             raise CoercionError, "#{input.inspect} cannot be coerced to hash"
           end
         end
+
+        # @param [Range, String, Object] input
+        #
+        # @return [Range, Object]
+        #
+        # @raise CoercionError
+        #
+        # @api public
+        def self.to_range(input, &_block)
+          if empty_str?(input)
+            nil
+          elsif input.is_a?(::Range)
+            input
+          elsif block_given?
+            yield
+          else
+            raise CoercionError, "#{input.inspect} cannot be coerced to range"
+          end
+        end
       end
     end
   end

--- a/lib/dry/types/compiler.rb
+++ b/lib/dry/types/compiler.rb
@@ -69,6 +69,12 @@ module Dry
         registry["nominal.hash"].with(**opts, meta: meta)
       end
 
+      def visit_range(node)
+        member, meta = node
+        member = member.is_a?(Class) ? member : visit(member)
+        registry["nominal.range"].of(member).meta(meta)
+      end
+
       def visit_schema(node)
         keys, options, meta = node
         registry["nominal.hash"].schema(keys.map { |key| visit(key) }).with(**options, meta: meta)

--- a/lib/dry/types/core.rb
+++ b/lib/dry/types/core.rb
@@ -31,7 +31,7 @@ module Dry
       date: Date,
       date_time: DateTime,
       time: Time,
-      range: Range
+      range: ::Range
     }.freeze
 
     # All built-in primitives
@@ -64,9 +64,8 @@ module Dry
 
     # Register {METHOD_COERCIBLE} types
     METHOD_COERCIBLE.each_key do |name|
-      register(
-        "coercible.#{name}", self["nominal.#{name}"].constructor(&METHOD_COERCIBLE_METHODS[name])
-      )
+      register("coercible.#{name}",
+               self["nominal.#{name}"].constructor(&METHOD_COERCIBLE_METHODS[name]))
     end
 
     # Register optional strict {NON_NIL} types

--- a/lib/dry/types/nominal.rb
+++ b/lib/dry/types/nominal.rb
@@ -28,6 +28,8 @@ module Dry
           Types::Array
         elsif primitive == ::Hash
           Types::Hash
+        elsif primitive == ::Range
+          Types::Range
         else
           self
         end

--- a/lib/dry/types/params.rb
+++ b/lib/dry/types/params.rb
@@ -52,6 +52,10 @@ module Dry
       self["nominal.hash"].constructor(Coercions::Params.method(:to_hash))
     end
 
+    register("params.range") do
+      self["nominal.range"].constructor(Coercions::Params.method(:to_range))
+    end
+
     register("params.symbol") do
       self["nominal.symbol"].constructor(Coercions::Params.method(:to_symbol))
     end

--- a/lib/dry/types/predicate_inferrer.rb
+++ b/lib/dry/types/predicate_inferrer.rb
@@ -30,6 +30,8 @@ module Dry
 
       ARRAY = %i[array?].freeze
 
+      RANGE = [type?: ::Range].freeze
+
       NIL = %i[nil?].freeze
 
       # Compiler reduces type AST into a list of predicates
@@ -112,6 +114,11 @@ module Dry
         # @api private
         def visit_array(_)
           ARRAY
+        end
+
+        # @api private
+        def visit_range(_)
+          RANGE
         end
 
         # @api private

--- a/lib/dry/types/primitive_inferrer.rb
+++ b/lib/dry/types/primitive_inferrer.rb
@@ -36,6 +36,11 @@ module Dry
         end
 
         # @api private
+        def visit_range(_)
+          ::Range
+        end
+
+        # @api private
         def visit_lax(node)
           visit(node)
         end

--- a/lib/dry/types/printer.rb
+++ b/lib/dry/types/printer.rb
@@ -23,6 +23,8 @@ module Dry
         Default::Callable => :visit_default,
         Sum => :visit_sum,
         Sum::Constrained => :visit_sum,
+        Range => :visit_range,
+        Range::Member => :visit_range_member,
         Any.class => :visit_any
       }
 
@@ -59,6 +61,20 @@ module Dry
         visit(array.member) do |type|
           visit_options(EMPTY_HASH, array.meta) do |opts|
             yield "Array<#{type}#{opts}>"
+          end
+        end
+      end
+
+      def visit_range(type)
+        visit_options(EMPTY_HASH, type.meta) do |opts|
+          yield "Range#{opts}"
+        end
+      end
+
+      def visit_range_member(range)
+        visit(range.member) do |type|
+          visit_options(EMPTY_HASH, range.meta) do |opts|
+            yield "Range<#{type}#{opts}>"
           end
         end
       end

--- a/lib/dry/types/range.rb
+++ b/lib/dry/types/range.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Dry
+  module Types
+    # Range type can be used to define a range with optional member type
+    #
+    # @api public
+    class Range < Nominal
+      # Build a range type with a member type
+      #
+      # @param [Type,#call] type
+      #
+      # @return [Range::Member]
+      #
+      # @api public
+      def of(type)
+        member =
+          case type
+          when String then Types[type]
+          else type
+          end
+
+        Range::Member.new(primitive, **options, member: member)
+      end
+
+      # @api private
+      def constructor_type
+        ::Dry::Types::Range::Constructor
+      end
+    end
+  end
+end

--- a/lib/dry/types/range/constructor.rb
+++ b/lib/dry/types/range/constructor.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Dry
+  module Types
+    # @api public
+    class Range < Nominal
+      # @api private
+      class Constructor < ::Dry::Types::Constructor
+        # @api private
+        def constructor_type
+          ::Dry::Types::Range::Constructor
+        end
+
+        # @return [Lax]
+        #
+        # @api public
+        def lax
+          Lax.new(type.lax.constructor(fn, meta: meta))
+        end
+
+        # @see Dry::Types::Range#of
+        #
+        # @api public
+        def of(member)
+          type.of(member).constructor(fn, meta: meta)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/types/range/member.rb
+++ b/lib/dry/types/range/member.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Dry
+  module Types
+    class Range < Nominal
+      # Member ranges define their member type that is applied to begin and end
+      #
+      # @api public
+      class Member < Range
+        # @return [Type]
+        attr_reader :member
+
+        # @param [Class] primitive
+        # @param [Hash] options
+        #
+        # @option options [Type] :member
+        #
+        # @api private
+        def initialize(primitive, **options)
+          @member = options.fetch(:member)
+          super
+        end
+
+        # @param [Object] input
+        #
+        # @return [Range]
+        #
+        # @api private
+        def call_unsafe(input)
+          if primitive?(input)
+            coerced_begin = member.call_unsafe(input.begin)
+            coerced_end = member.call_unsafe(input.end)
+
+            coerced_begin = nil if Undefined.equal?(coerced_begin)
+            coerced_end = nil if Undefined.equal?(coerced_end)
+
+            coerced_begin..coerced_end
+          else
+            super
+          end
+        end
+
+        # @param [Object] input
+        # @return [Range]
+        #
+        # @api private
+        def call_safe(input)
+          if primitive?(input)
+            failed = false
+
+            coerced_begin = member.call_safe(input.begin) { |out = input.begin|
+              failed = true
+              out
+            }
+
+            coerced_end = member.call_safe(input.end) { |out = input.end|
+              failed = true
+              out
+            }
+
+            coerced_begin = nil if Undefined.equal?(coerced_begin)
+            coerced_end = nil if Undefined.equal?(coerced_end)
+
+            output = coerced_begin..coerced_end
+
+            failed ? yield(output) : output
+          else
+            yield
+          end
+        end
+
+        # @param [Range, Object] input
+        # @param [#call,nil] block
+        #
+        # @yieldparam [Failure] failure
+        # @yieldreturn [Result]
+        #
+        # @return [Result,Logic::Result]
+        #
+        # @api public
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/PerceivedComplexity
+        def try(input, &block)
+          if primitive?(input)
+            result_begin = member.try(input.begin)
+            result_end = member.try(input.end)
+
+            output_begin = Undefined.equal?(result_begin.input) ? nil : result_begin.input
+            output_end = Undefined.equal?(result_end.input) ? nil : result_end.input
+            output = output_begin..output_end
+
+            if result_begin.success? && result_end.success?
+              success(output)
+            else
+              error = result_begin.failure? && result_begin.error ||
+                      result_end.failure? && result_end.error
+              failure = failure(output, error)
+              block ? yield(failure) : failure
+            end
+          else
+            failure = failure(input, CoercionError.new("#{input} is not a range"))
+            block ? yield(failure) : failure
+          end
+        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        # Build a lax type
+        #
+        # @return [Lax]
+        #
+        # @api public
+        def lax
+          Lax.new(Member.new(primitive, **options, member: member.lax, meta: meta))
+        end
+
+        # @see Nominal#to_ast
+        #
+        # @api public
+        def to_ast(meta: true)
+          if member.respond_to?(:to_ast)
+            [:range, [member.to_ast(meta: meta), meta ? self.meta : EMPTY_HASH]]
+          else
+            [:range, [member, meta ? self.meta : EMPTY_HASH]]
+          end
+        end
+
+        # @api private
+        def constructor_type
+          ::Dry::Types::Range::Constructor
+        end
+      end
+    end
+  end
+end

--- a/spec/dry/types/compiler_spec.rb
+++ b/spec/dry/types/compiler_spec.rb
@@ -172,6 +172,37 @@ RSpec.describe Dry::Types::Compiler, "#call" do
     expect(arr[%w[1 2 3]]).to eql([1, 2, 3])
   end
 
+  it "builds an range" do
+    ast = Dry::Types["nominal.range"].of(Dry::Types["nominal.integer"]).to_ast
+
+    range = compiler.(ast)
+
+    expect(range).to be_a(Dry::Types::Range)
+
+    input = 1..2
+
+    expect(range[input]).to eql(1..2)
+  end
+
+  it "builds a lax params range" do
+    ast = Dry::Types["params.range"].lax.to_ast
+
+    range = compiler.(ast)
+
+    expect(range["oops"]).to eql("oops")
+    expect(range[""]).to be nil
+    expect(range[1..2]).to eql(1..2)
+  end
+
+  it "builds a lax params range with member" do
+    ast = Dry::Types["params.range"].of(Dry::Types["coercible.integer"]).lax.to_ast
+
+    range = compiler.(ast)
+
+    expect(range["oops"]).to eql("oops")
+    expect(range[1..2.0]).to eql(1..2)
+  end
+
   it "builds a safe params hash" do
     type = Dry::Types["params.hash"].schema(
       email: Dry::Types["nominal.string"],

--- a/spec/dry/types/module_spec.rb
+++ b/spec/dry/types/module_spec.rb
@@ -52,6 +52,14 @@ RSpec.describe Dry::Types::Module do
       end
     end
 
+    describe ".Range" do
+      it "builds an range type" do
+        expect(mod.Range(mod::Strict::Integer)).to eql(
+          Dry::Types["strict.range<strict.integer>"]
+        )
+      end
+    end
+
     describe ".Map" do
       it "builds a map type" do
         expected = Dry::Types::Map.new(::Hash, key_type: Dry::Types["strict.integer"])

--- a/spec/dry/types/predicate_inferrer_spec.rb
+++ b/spec/dry/types/predicate_inferrer_spec.rb
@@ -96,6 +96,14 @@ RSpec.describe Dry::Types::PredicateInferrer, "#[]" do
     expect(inferrer[type(:hash).schema(name: "string")]).to eql([:hash?])
   end
 
+  it "returns range? for an range type" do
+    expect(inferrer[type(:range)]).to eql([type?: Range])
+  end
+
+  it "returns range? for an range type with member" do
+    expect(inferrer[type(:range).of(type(:integer))]).to eql([type?: Range])
+  end
+
   context "constrained types" do
     it "extracts predicates from contrained types" do
       expect(inferrer[type(:integer).constrained(gteq: 18)]).to eql([:int?, gteq?: 18])

--- a/spec/dry/types/range_spec.rb
+++ b/spec/dry/types/range_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+RSpec.describe Dry::Types::Range do
+  describe "#of" do
+    context "primitive" do
+      shared_context "range with a member type" do
+        it_behaves_like Dry::Types::Nominal do
+          subject(:type) { range }
+        end
+      end
+
+      context "using string identifiers" do
+        subject(:range) { Dry::Types["nominal.range<coercible.string>"] }
+
+        include_context "range with a member type"
+      end
+
+      context "using method" do
+        subject(:range) { Dry::Types["nominal.range"].of(Dry::Types["coercible.integer"]) }
+
+        include_context "range with a member type"
+      end
+
+      context "coercing dates" do
+        subject(:range) { Dry::Types["nominal.range"].of(Dry::Types["params.date"]) }
+
+        it "coerces members to dates" do
+          start_on = Date.new(2022, 9, 6)
+          end_on = Date.new(2022, 9, 7)
+          expect(range[start_on.to_s..end_on.to_s]).to eql(start_on..end_on)
+        end
+      end
+
+      context "try" do
+        subject(:range) { Dry::Types["nominal.range"].of(Dry::Types["strict.integer"]) }
+
+        it "with a valid range" do
+          expect(range.try(1..2)).to eq Dry::Types::Result::Success.new(1..2)
+        end
+
+        it "with a valid range" do
+          expect(range.try(1..2)).to be_success
+        end
+
+        it "an invalid type should be a failure" do
+          expect(range.try("some string")).to be_failure
+        end
+
+        it "a broken constraint should be a failure" do
+          expect(range.try(1..2.0)).to be_failure
+        end
+
+        it "a broken constraint with block" do
+          expect(
+            range.try(1..2.0) { |error| "error: #{error}" }
+          ).to match("error: 2.0 violates constraints (type?(Integer, 2.0) failed)")
+        end
+
+        it "an invalid type with a block" do
+          expect(
+            range.try("X") { |x| "error: #{x}" }
+          ).to eql("error: X is not a range")
+        end
+      end
+
+      context "using a constrained type" do
+        subject(:range) do
+          Dry::Types["range"].of(Dry::Types["coercible.integer"].constrained(gt: 2))
+        end
+
+        it "passes values through member type" do
+          expect(range[3..5]).to eql(3..5)
+        end
+
+        it "raises when input is not valid" do
+          expect { range["1".."3"] }.to raise_error(
+            Dry::Types::ConstraintError,
+            '"1" violates constraints (gt?(2, 1) failed)'
+          )
+        end
+
+        it_behaves_like Dry::Types::Nominal do
+          subject(:type) { range }
+
+          it_behaves_like "a composable constructor"
+        end
+      end
+
+      context "undefined" do
+        subject(:range) do
+          Dry::Types["range"].of(
+            Dry::Types["nominal.integer"].constructor { |value|
+              value == 2 ? Dry::Types::Undefined : value
+            }
+          )
+        end
+
+        it "filters out undefined values" do
+          expect(range[1..2]).to eql(1..)
+        end
+      end
+    end
+  end
+
+  describe "#valid?" do
+    subject(:range) { Dry::Types["range"].of(Dry::Types["float"]) }
+
+    it "detects invalid input of the completely wrong type" do
+      expect(range.valid?(5)).to be(false)
+    end
+
+    it "detects invalid input of the wrong member type" do
+      expect(range.valid?(1..2)).to be(false)
+    end
+
+    it "recognizes valid input" do
+      expect(range.valid?(1.0..2.0)).to be(true)
+    end
+  end
+
+  describe "#===" do
+    subject(:range) { Dry::Types["strict.range"].of(Dry::Types["strict.integer"]) }
+
+    it "returns boolean" do
+      expect(range.===(1..2)).to eql(true)
+      expect(range.===(1..2.0)).to eql(false)
+    end
+
+    context "in case statement" do
+      let(:value) do
+        case 1..2
+        when range then "accepted"
+        else "invalid"
+        end
+      end
+
+      it "returns correct value" do
+        expect(value).to eql("accepted")
+      end
+    end
+  end
+
+  context "member" do
+    describe "#to_s" do
+      subject(:type) { Dry::Types["nominal.range"].of(Dry::Types["nominal.string"]) }
+
+      it "returns string representation of the type" do
+        expect(type.to_s).to eql("#<Dry::Types[Range<Nominal<String>>]>")
+      end
+
+      it "shows meta" do
+        expect(type.meta(foo: :bar).to_s).to eql("#<Dry::Types[Range<Nominal<String> meta={foo: :bar}>]>")
+      end
+    end
+
+    describe "#constructor" do
+      subject(:type) { Dry::Types["params.range<params.integer>"] }
+
+      it "gets member from a constructor type" do
+        expect(type.member.("1")).to be(1)
+      end
+
+      describe "#lax" do
+        subject(:type) { Dry::Types["range<integer>"].constructor(&:to_a) }
+
+        it "makes type recursively lax" do
+          expect(type.lax.member).to eql(Dry::Types["nominal.integer"])
+        end
+      end
+
+      describe "#constrained" do
+        it "applies constraints on top of constructor" do
+          expect(type.constrained(eql: 1..2).(1..2)).to eql(1..2)
+          expect(type.constrained(eql: 1..2).(1..3) { :fallback }).to be(:fallback)
+        end
+      end
+    end
+
+    context "nested range" do
+      let(:strings) do
+        Dry::Types["range"].of("string")
+      end
+
+      subject(:type) do
+        Dry::Types["range"].of(strings)
+      end
+
+      it "still discards constructor" do
+        expect(type.constructor(&:to_a).member.type).to eql(strings)
+      end
+    end
+  end
+
+  describe "#to_s" do
+    subject(:type) { Dry::Types["nominal.range"] }
+
+    it "returns string representation of the type" do
+      expect(type.to_s).to eql("#<Dry::Types[Range]>")
+    end
+
+    it "adds meta" do
+      expect(type.meta(foo: :bar).to_s).to eql("#<Dry::Types[Range meta={foo: :bar}]>")
+    end
+  end
+end

--- a/spec/dry/types/to_ast_spec.rb
+++ b/spec/dry/types/to_ast_spec.rb
@@ -205,4 +205,46 @@ RSpec.describe Dry::Types, "#to_ast" do
       end
     end
   end
+
+  context "Range" do
+    subject(:type) { Dry::Types["nominal.range"] }
+
+    specify do
+      expect(type.to_ast).to eql([:nominal, [Range, {}]])
+    end
+
+    specify "with meta" do
+      expect(type_with_meta.to_ast).to eql([:nominal, [Range, key: :value]])
+    end
+
+    context "Member" do
+      subject(:type) do
+        Dry::Types["nominal.range"].of(Dry::Types["nominal.string"])
+      end
+
+      specify do
+        expect(type.to_ast).to eql([:range, [[:nominal, [String, {}]], {}]])
+      end
+
+      specify "with meta" do
+        expect(type_with_meta.to_ast).to eql(
+          [:range, [[:nominal, [String, {}]], key: :value]]
+        )
+      end
+    end
+
+    context "Member of structs" do
+      let(:struct) do
+        Test::Struct = Class.new { extend Dry::Types::Type }
+      end
+
+      subject(:type) do
+        Dry::Types["nominal.range"].of(struct)
+      end
+
+      specify do
+        expect(type.to_ast).to eql([:range, [struct, {}]])
+      end
+    end
+  end
 end

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -238,6 +238,24 @@ RSpec.describe Dry::Types::Nominal do
     end
   end
 
+  describe "params.range" do
+    subject(:type) { Dry::Types["params.range"].of(Dry::Types["params.integer"]) }
+
+    it_behaves_like "a constrained type", inputs: [
+      Object.new, "foo", "23asf", {}
+    ]
+
+    it "returns coerced range" do
+      range = "1".."2"
+      expect(type[range]).to eql(1..2)
+    end
+
+    it "coerces an empty string into nil" do
+      input = ""
+      expect(type[input]).to be nil
+    end
+  end
+
   describe "params.symbol" do
     subject(:type) { Dry::Types["params.symbol"] }
 


### PR DESCRIPTION
Hi, I'd like to use dry-schema for an application dealing with lots of ranges. The current support for ranges in dry-types doesn't handle checks for its member values, which is the issue this PR is trying to solve.

I've based my work on the current implementation for arrays and tried to include everything from test to documentation. Coding was pretty straightforward considering I don't have much experience with dry libraries.

Here's an example of using this feature:
``` ruby
IntegerRange = Types::Range.of(Types::Coercible::Integer)
IntegerRange[1.0..2.0] # 1..2
```

### Things to improve
* support for `exclude_end` option
* `range?` predicate in dry-logic
