### PR TITLE
Fixed duplicate key warning

### DIFF
--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -24,7 +24,7 @@ module Dry
       # @api public
       def self.new(input, **options, &block)
         type = input.is_a?(Builder) ? input : Nominal.new(input)
-        super(type, **options, fn: Function[options.fetch(:fn, block)])
+        super(type, **options.merge(fn: Function[options.fetch(:fn, block)]))
       end
 
       # @param [Builder, Object] input


### PR DESCRIPTION
Without this change, our logs are getting filled with these ruby warnings:
```
warning: key :fn is duplicated and overwritten on line 27
```