### PR TITLE
Give Enum types a name with meaningful information

### DIFF
--- a/lib/dry/types/enum.rb
+++ b/lib/dry/types/enum.rb
@@ -33,6 +33,10 @@ module Dry
         freeze
       end
 
+      def name
+        "#{super}[#{values.join('|')}]"
+      end
+
       # @return [Object]
       #
       # @api private


### PR DESCRIPTION
The name of enum types don't display their state information.

Given: `Strict::String.enum(['pending', 'active', 'frozen', 'in_review', 'banned', 'incomplete']).optional.name`
Before: `String | NilClass`
After: `String[pending|active|frozen|in_review|banned|incomplete] | NilClass`