### PR TITLE
Fixed BigDecimal warning

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,4 +1,8 @@
 ---
+- version: 1.7.2
+  date: 2024-01-04
+  fixed:
+  - "Fixed BigDecimal warning due to not being required in gemspec (@bkuhlmann in #464)"
 - version: 1.7.1
   date: 2023-02-17
   fixed:

--- a/dry-types.gemspec
+++ b/dry-types.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0"
 
   # to update dependencies edit project.yml
+  spec.add_runtime_dependency "bigdecimal", "~> 3.0"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "dry-core", "~> 1.0"
   spec.add_runtime_dependency "dry-inflector", "~> 1.0"

--- a/lib/dry/types/version.rb
+++ b/lib/dry/types/version.rb
@@ -2,6 +2,6 @@
 
 module Dry
   module Types
-    VERSION = "1.7.1"
+    VERSION = "1.7.2"
   end
 end

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,7 @@ gemspec:
     - rspec
     - yard
   runtime_dependencies:
+    - [bigdecimal, "~> 3.0"]
     - [concurrent-ruby, "~> 1.0"]
     - [zeitwerk, "~> 2.6"]
     - [dry-core, "~> 1.0"]


### PR DESCRIPTION
## Overview

The following ensures BigDecimal is required in the `gemspec` so warnings are resolved when using Ruby 3.3.0. This is backward compatible for all supported Ruby versions of this project.

## Details

Resolves #464.