### PR TITLE
Added documentation for intersection types

### DIFF
--- a/docsite/source/combining-types.html.md
+++ b/docsite/source/combining-types.html.md
@@ -1,0 +1,12 @@
+---
+title: Combining Types
+layout: gem-single
+name: dry-types
+sections:
+  - intersection
+  - sum
+order: 11
+---
+
+Types can be combined to create new types, using [intersection types](docs::combining-types/intersection)
+to further restrict values, and [sum types](docs::combining-types/sum) to allow more acceptable values.

--- a/docsite/source/combining-types/sum.html.md
+++ b/docsite/source/combining-types/sum.html.md
@@ -2,7 +2,6 @@
 title: Sum
 layout: gem-single
 name: dry-types
-order: 7
 ---
 
 You can specify sum types using `|` operator, it is an explicit way of defining what the valid types of a value are.

--- a/docsite/source/intersection.html.md
+++ b/docsite/source/intersection.html.md
@@ -1,0 +1,23 @@
+---
+title: Intersection
+layout: gem-single
+name: dry-types
+order: 8
+---
+
+Intersection types are specified using the `&` operator. It combines two
+compatible types into a single one with properties from each.
+
+One example is a `Hash` that allows any keys, but requires one of them to be named `id`:
+
+```ruby
+Id = Types::Hash.schema(id: Types::Integer)
+HashWithId = Id & Types::Hash
+
+Id[{id: 1}]                             # => {:id=>1}
+Id[{id: 1, message: 'foo'}]             # => {:id=>1}
+Id[{message: 'foo'}]                    # => Dry::Types::MissingKeyError: :id is missing in Hash input
+
+HashWithId[{ message: 'hello' }]        # => Dry::Types::MissingKeyError: :id is missing in Hash input
+HashWithId[{ id: 1, message: 'hello' }] # => {:id=>1, :message=>"hello"}
+```


### PR DESCRIPTION
I was working on a project and wanted this functionality, happened to just try using `&` and it actually worked -- but discovered that this was still an undocumented feature.

So, I wrote up a short page about it, using an example from my real world project.

I also arranged sum & intersection pages under a "Combining Types" section, and placed it after constraints and hash schemas, since this sort of builds on top of those ideas. I didn't see a way to actually test the docsite generation, so hopefully it looks good.