### PR TITLE
Provide a consistent interface for specifying nullary constraints

### DIFF
--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -72,8 +72,8 @@ module Dry
       # @return [Constrained]
       #
       # @api public
-      def constrained(options)
-        constrained_type.new(self, rule: Types.Rule(options))
+      def constrained(...)
+        constrained_type.new(self, rule: Types.Rule(...))
       end
 
       # Turn a type into a type with a default value

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -75,8 +75,9 @@ module Dry
         end
       end
 
-      # @param [Hash] options
-      #   The options hash provided to {Types.Rule} and combined
+      # @param *nullary_rules [Array<Symbol>] a list of rules that do not require an additional argument (e.g., :odd)
+      # @param **unary_rules [Hash] a list of rules that require an additional argument (e.g., gt: 0)
+      #   The parameters are merger to create a rules hash provided to {Types.Rule} and combined
       #   using {&} with previous {#rule}
       #
       # @return [Constrained]

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -84,8 +84,12 @@ module Dry
       # @see Dry::Logic::Operators#and
       #
       # @api public
-      def constrained(options)
-        with(rule: rule & Types.Rule(options))
+      def constrained(*nullary_rules, **unary_rules)
+        nullary_rules_hash = parse_arguments(nullary_rules)
+
+        rules = nullary_rules_hash.merge(unary_rules)
+
+        with(rule: rule & Types.Rule(rules))
       end
 
       # @return [true]
@@ -132,6 +136,17 @@ module Dry
       # @api private
       def decorate?(response)
         super || response.is_a?(Constructor)
+      end
+
+      # @param [Array] positional_args
+      #
+      # @return [Hash]
+      #
+      # @api private
+      def parse_arguments(positional_arguments)
+        return positional_arguments.first if positional_arguments.first.is_a?(::Hash)
+
+        positional_arguments.flatten.zip([]).to_h
       end
     end
   end

--- a/lib/dry/types/constrained.rb
+++ b/lib/dry/types/constrained.rb
@@ -75,8 +75,10 @@ module Dry
         end
       end
 
-      # @param *nullary_rules [Array<Symbol>] a list of rules that do not require an additional argument (e.g., :odd)
-      # @param **unary_rules [Hash] a list of rules that require an additional argument (e.g., gt: 0)
+      # @param *nullary_rules [Array<Symbol>] a list of rules that do not require an additional
+      #   argument (e.g., :odd)
+      # @param **unary_rules [Hash] a list of rules that require an additional argument
+      #   (e.g., gt: 0)
       #   The parameters are merger to create a rules hash provided to {Types.Rule} and combined
       #   using {&} with previous {#rule}
       #

--- a/lib/dry/types/sum.rb
+++ b/lib/dry/types/sum.rb
@@ -84,9 +84,9 @@ module Dry
       # @see Builder#constrained
       #
       # @api public
-      def constrained(options)
+      def constrained(...)
         if optional?
-          right.constrained(options).optional
+          right.constrained(...).optional
         else
           super
         end

--- a/spec/dry/types/predicate_inferrer_spec.rb
+++ b/spec/dry/types/predicate_inferrer_spec.rb
@@ -101,13 +101,29 @@ RSpec.describe Dry::Types::PredicateInferrer, "#[]" do
       expect(inferrer[type(:integer).constrained(gteq: 18)]).to eql([:int?, gteq?: 18])
     end
 
-    it "works with rules without additional parameters" do
-      expect(inferrer[type(:integer).constrained([:odd])]).to eql([:int?, :odd?])
+    it "works with nullary rules" do
+      expect(inferrer[type(:integer).constrained(:odd, :even)]).to eql([:int?, :odd?, :even?])
     end
 
-    it "can extract many rules" do
+    it "works with array of nullary rules" do
+      expect(inferrer[type(:integer).constrained([:odd, :even])]).to eql([:int?, :odd?, :even?])
+    end
+
+    it "works with combination of nullary and unary rules" do
       expect(
-        inferrer[type(:integer).constrained(gteq: 18, lt: 100)]
+        inferrer[type(:integer).constrained(:odd, gteq: 18, lt: 100)]
+      ).to eql([:int?, :odd?, gteq?: 18, lt?: 100])
+    end
+
+    it "works with array of nullary rules with unary rules" do
+      expect(
+        inferrer[type(:integer).constrained([:odd, :even], gteq: 18, lt: 100)]
+      ).to eql([:int?, :odd?, :even?, gteq?: 18, lt?: 100])
+    end
+
+    it "works with hash of unary rules" do
+      expect(
+        inferrer[type(:integer).constrained({gteq: 18, lt: 100})]
       ).to eql([:int?, gteq?: 18, lt?: 100])
     end
 


### PR DESCRIPTION
Closes #473

Implements the following api for specifying nullary constraints (no additional argument needed, e.g., `:odd`) and unary constraints (additional argument needed, e.g., `gt: 18`).

```ruby
type.constrained(:odd) # new variant
type.constrained(:odd, :even) # new variant
type.constrained(:odd, gt: 200, lt: 300) # new variant
```

The above is covered by new tests and updated yardocs. If this api is acceptable, I will update the docsite accordingly.

## Addenda

The api also accepts the following for backward compatibility. However, I suggest deprecating this behavior as non-intuitive and dependent on a quirk of the former implementation (`#map`). Deprecating will allow for the removal of an otherwise unnecessary application of `Array#flatten` in processing arguments.

```ruby
type.constrained([:odd, :even]) # worked before, continue to support
type.constrained([:odd, :even], gt: 200, lt: 300) # new variant, supported as a side-effect
```
The following also work, although I don't believe they are covered by tests. The last two are no-ops.

```ruby
type.constrained # error, as before
type.constrained([]) # worked before, continue to support
type.constrained({}) # worked before, continue to support
```

Finally, the following also work as undocumented behavior.

```ruby
type.constrained({gteq: 0, lt: 100}) # undocumented, not encouraged
type.constrained({gteq: 0}, lt: 100) # undocumented, not encouraged
```

## Potential Issues

- Dry::Types::Sum.constrained (on line 89) does not double-splat the options Hash used to call `Constrained#constrained`, which means that it relies on the "undocumented" behavior above. Not a big deal, but I would consider adding `**` for clarity or, even better, using argument forwarding (`...`).

- Dry::Types::Builder.constrained does not implement the above api. Although this does not break current tests, this should probably be modified (with tests) to be consistent. Maybe just use argument forwarding here as well?