### PR TITLE
Allows Default to return the right Result

### DIFF
--- a/lib/dry/types/default.rb
+++ b/lib/dry/types/default.rb
@@ -79,7 +79,7 @@ module Dry
       #
       # @api public
       def try(input)
-        success(call(input))
+        type.try(input)
       end
 
       # @return [Boolean]

--- a/spec/dry/types/default_spec.rb
+++ b/spec/dry/types/default_spec.rb
@@ -125,6 +125,18 @@ RSpec.describe Dry::Types::Builder, "#default" do
     end
   end
 
+  describe "#try" do
+    subject(:type) { Dry::Types["integer"].default(1) }
+
+    it "returns a success result for valid input" do
+      expect(type.try(5)).to be_success
+    end
+
+    it "returns a failure result for invalid input" do
+      expect(type.try("five")).to be_failure
+    end
+  end
+
   describe "#with" do
     subject(:type) { Dry::Types["nominal.time"].default { Time.now }.meta(foo: :bar) }
 


### PR DESCRIPTION
Fixes instances when a Default type runs `#try` with a failing value.

Closes #469

```ruby
Types::Integer.default(1).try("a")
# => #<Dry::Types::Result::Failure input="a" error=#<Dry::Types::ConstraintError: "a" violates constraints (type?(Integer, "a") failed)>>
```