### PR TITLE
Fix params.*.optional to handle empty strings consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `params.*.optional` now handles empty strings consistently with `optional.params.*` by returning `nil` instead of raising an error (fixes #419) (@baweaver)
 
 ## [1.8.3] - 2025-06-09
 

--- a/lib/dry/types/builder.rb
+++ b/lib/dry/types/builder.rb
@@ -50,7 +50,13 @@ module Dry
       # @return [Sum]
       #
       # @api public
-      def optional = Types["nil"] | self
+      def optional
+        if params_type?
+          Types["params.nil"] | self
+        else
+          Types["nil"] | self
+        end
+      end
 
       # Turn a type into a constrained type
       #
@@ -199,6 +205,15 @@ module Dry
           end
 
         klass.new(self, other)
+      end
+
+      private
+
+      def params_type?
+        return false unless is_a?(Constructor)
+        return false unless fn.is_a?(Constructor::Function::MethodCall)
+        
+        fn.target == Dry::Types::Coercions::Params
       end
     end
   end

--- a/spec/dry/types/types/params_spec.rb
+++ b/spec/dry/types/types/params_spec.rb
@@ -272,5 +272,14 @@ RSpec.describe Dry::Types::Nominal do
     it "raises an error on random strings" do
       expect { type["abc"] }.to raise_error(Dry::Types::CoercionError)
     end
+
+    context "consistency between .optional and Optional::" do
+      it "handles empty strings the same way" do
+        optional_namespace = Dry::Types["optional.params.integer"]
+        dot_optional = Dry::Types["params.integer"].optional
+
+        expect(optional_namespace[""]).to eq(dot_optional[""])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Fix `params.*.optional` to handle empty strings consistently

Fixes #419

### Problem

`params.*.optional` and `optional.params.*` handle empty strings differently:

• `Types::Params::Integer.optional['']` raises `CoercionError`
• `Types::Optional::Params::Integer['']` returns `nil`

This inconsistency is confusing for users who expect both forms to behave the same way.

### Solution

Modified the `.optional` method to detect params types and use `params.nil` instead of regular `nil` when creating the sum type. This ensures empty strings are properly converted to nil.

### Changes

• Update `Builder#optional` to use `params.nil | self` for params types
• Add `params_type?` helper method to detect constructor types using `Params` coercions
• Add test case to verify consistency between the two forms

### Breaking Change

`params.*.optional['']` now returns `nil` instead of raising a `CoercionError`. Code that was catching and handling this error will need to be updated.

### Testing

• All existing tests pass
• New test verifies both forms handle empty strings identically
• Verified fix works for all params types (integer, date, etc.)