### PR TITLE
Revert JRuby workaround

### DIFF
--- a/lib/dry/types/array/member.rb
+++ b/lib/dry/types/array/member.rb
@@ -42,7 +42,7 @@ module Dry
         # @return [Array]
         #
         # @api private
-        def call_safe(input, &block)
+        def call_safe(input)
           if primitive?(input)
             failed = false
 
@@ -55,9 +55,9 @@ module Dry
               output << coerced unless Undefined.equal?(coerced)
             end
 
-            failed ? block.call(result) : result
+            failed ? yield(result) : result
           else
-            block.call
+            yield
           end
         end
 

--- a/lib/dry/types/constructor.rb
+++ b/lib/dry/types/constructor.rb
@@ -69,13 +69,9 @@ module Dry
       # @return [Object]
       #
       # @api private
-      def call_safe(input, &block)
-        # block.call is slower in JRuby than yield, but in JRuby 10.0.2.0 there is a bug
-        # with default block arguments, so block.call is chosen for correctness.
-        # This was introduced in PR https://github.com/dry-rb/dry-types/pull/493, might be reverted
-        # in the bug is fixed in JRuby.
-        coerced = fn.(input) { |output = input| return block.call(output) }
-        type.call_safe(coerced) { |output = coerced| block.call(output) }
+      def call_safe(input)
+        coerced = fn.(input) { |output = input| return yield(output) }
+        type.call_safe(coerced) { |output = coerced| yield(output) }
       end
 
       # @return [Object]


### PR DESCRIPTION
Reverts cdff1829871839f41b93d4eb7904cd6cda9a4a22

The workaround was needed due to a bug in JRuby. The bug has since then been fixed and should be released in 10.0.4.0. Once this happens, this PR could be merged. So far I verified manually that the tests pass with current JRuby head.